### PR TITLE
PyPI publishing: get rid of composite action

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: publish-wheel
-description: Publish wheel
+name: build-wheel
+description: Build wheel and sdist
 
 inputs:
   package_directory:
@@ -28,6 +28,9 @@ outputs:
   package_name:
     description: .whl package name
     value: ${{ steps.package_name.outputs.package_name }}
+  sdist_name:
+    description: .tar.gz sdist name
+    value: ${{ steps.sdist_name.outputs.sdist_name }}
 
 runs:
   using: "composite"
@@ -54,8 +57,20 @@ runs:
       run: echo package_name=$(basename ${{ inputs.package_directory }}/dist/*.whl) >> "$GITHUB_OUTPUT"
       shell: bash
 
+    # Note: the sdist file is built in package_directory/dist
+    - name: Find sdist filename
+      id: sdist_name
+      run: echo sdist_name=$(basename ${{ inputs.package_directory }}/dist/*.tar.gz) >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Save wheel package as artifact
       uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.package_name.outputs.package_name }}
         path: ${{ inputs.package_directory }}/dist/${{ steps.package_name.outputs.package_name }}
+
+    - name: Save sdist as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.sdist_name.outputs.sdist_name }}
+        path: ${{ inputs.package_directory }}/dist/${{ steps.sdist_name.outputs.sdist_name }}

--- a/.github/actions/publish-wheel/action.yml
+++ b/.github/actions/publish-wheel/action.yml
@@ -59,12 +59,3 @@ runs:
       with:
         name: ${{ steps.package_name.outputs.package_name }}
         path: ${{ inputs.package_directory }}/dist/${{ steps.package_name.outputs.package_name }}
-
-    - name: Publish wheel and sdist packages
-      uses: pypa/gh-action-pypi-publish@release/v1
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      with:
-        skip-existing: true
-        packages-dir: ${{ inputs.package_directory }}/dist
-        #repository-url: https://test.pypi.org/legacy/
-        verbose: true

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -103,6 +103,13 @@ jobs:
         uses: ./.github/actions/publish-wheel
         with:
           package_directory: .
+      - name: Publish wheel and sdist packages
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        with:
+          skip-existing: true
+          packages-dir: ./dist
+          verbose: true
 
 
   #########################

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -82,27 +82,44 @@ jobs:
           echo "docker_tag=$docker_tag" >> $GITHUB_OUTPUT
         shell: bash
 
-  ##################
-  # Publish wheels #
-  ##################
+  ################
+  # Build wheels #
+  ################
 
-  publish-whl:
+  build-whl:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
-    name: "Publish wheel"
-    permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    name: "Build wheel"
     outputs:
-      version_name: ${{ steps.publish-wheel.outputs.version_name }}
-      package_name: ${{ steps.publish-wheel.outputs.package_name }}
+      version_name: ${{ steps.build-wheel.outputs.version_name }}
+      package_name: ${{ steps.build-wheel.outputs.package_name }}
+      sdist_name: ${{ steps.build-wheel.outputs.sdist_name }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # so that Dunamai produce the correct version
-      - id: publish-wheel
-        uses: ./.github/actions/publish-wheel
+      - id: build-wheel
+        uses: ./.github/actions/build-wheel
         with:
           package_directory: .
+
+  ###################
+  # Publish to PyPI #
+  ###################
+
+  publish-pypi:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    name: "Publish wheel and sdist"
+    needs: [build-whl]
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - name: Download dist dependencies
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: ./dist
       - name: Publish wheel and sdist packages
         uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
@@ -120,7 +137,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     name: "Docker image for wheel storage"
-    needs: [set-env, publish-whl]
+    needs: [set-env, build-whl]
     permissions: write-all
     outputs:
       docker_image: ${{ steps.publish-docker.outputs.docker_image}}
@@ -131,7 +148,7 @@ jobs:
       - name: Download .whl dependencies
         uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.publish-whl.outputs.package_name }}
+          name: ${{ needs.build-whl.outputs.package_name }}
           path: ./whl
 
       - id: publish-docker
@@ -140,7 +157,7 @@ jobs:
           dockerfile: ./.github/dockerfiles/Dockerfile.store
           build_context_path: ./whl
           image_suffix: _store
-          version_name: ${{ needs.publish-whl.outputs.version_name }}
+          version_name: ${{ needs.build-whl.outputs.version_name }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           docker_tag: ${{ needs.set-env.outputs.docker_tag }}
 
@@ -148,7 +165,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     name: "Docker image for Jupyter"
-    needs: [set-env, publish-whl]
+    needs: [set-env, build-whl]
     permissions: write-all
     outputs:
       docker_image: ${{ steps.publish-docker.outputs.docker_image}}
@@ -159,7 +176,7 @@ jobs:
       - name: Download .whl dependencies
         uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.publish-whl.outputs.package_name }}
+          name: ${{ needs.build-whl.outputs.package_name }}
           path: ./whl
 
       - id: publish-docker
@@ -168,7 +185,7 @@ jobs:
           dockerfile: ./.github/dockerfiles/Dockerfile.jupyter
           build_context_path: ./whl
           image_suffix: _jupyter
-          version_name: ${{ needs.publish-whl.outputs.version_name }}
+          version_name: ${{ needs.build-whl.outputs.version_name }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           docker_tag: ${{ needs.set-env.outputs.docker_tag }}
 


### PR DESCRIPTION
 v1.12.0 and newer releases don't support nested invocations from composite actions

See https://github.com/pypa/gh-action-pypi-publish/issues/299