### PR TITLE
Owner_id is only useful for Catalog client

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -212,7 +212,10 @@ jobs:
         run: |
           set -x
           poetry run pytest $(find . -name tests) \
+            -ra --disable-pytest-warnings \
+            --color=yes \
             --durations=0 \
+            --durations-min=0.05 \
             --error-for-skips \
             --cov=./rs_client \
             --cov=./rs_common \
@@ -226,6 +229,7 @@ jobs:
           dummy="/tmp/empty-pytest"
           mkdir -p $dummy
           poetry run pytest $dummy \
+            --disable-pytest-warnings \
             --cov=$dummy \
             --cov-report=term \
             --cov-report=xml:./cov-report.xml \

--- a/rs_client/auxip_client.py
+++ b/rs_client/auxip_client.py
@@ -32,7 +32,6 @@ class AuxipClient(StacBase):
         self,
         rs_server_href: str | None,
         rs_server_api_key: str | None,
-        owner_id: str | None,
         logger: logging.Logger | None = None,
         **kwargs: dict[str, Any],
     ):
@@ -42,7 +41,6 @@ class AuxipClient(StacBase):
         Args:
             rs_server_href (str | None): The URL of the RS-Server. Pass None for local mode.
             rs_server_api_key (str | None): API key for authentication.
-            owner_id (str | None): ID of the catalog owner.
             logger (logging.Logger | None, optional): Logger instance (default: None).
             **kwargs: Arbitrary keyword arguments that may include:
                 - `headers` (Optional[Dict[str, str]])
@@ -56,7 +54,7 @@ class AuxipClient(StacBase):
         super().__init__(
             rs_server_href,
             rs_server_api_key,
-            owner_id,
+            None,
             logger,
             get_href_service(rs_server_href, "RSPY_HOST_ADGS") + "/auxip/",
             **kwargs,

--- a/rs_client/cadip_client.py
+++ b/rs_client/cadip_client.py
@@ -32,7 +32,6 @@ class CadipClient(StacBase):
         self,
         rs_server_href: str | None,
         rs_server_api_key: str | None,
-        owner_id: str | None,
         logger: logging.Logger | None = None,
         **kwargs: dict[str, Any],
     ):
@@ -42,7 +41,6 @@ class CadipClient(StacBase):
         Args:
             rs_server_href (str | None): The URL of the RS-Server. Pass None for local mode.
             rs_server_api_key (str | None): API key for authentication.
-            owner_id (str | None): ID of the catalog owner.
             logger (logging.Logger | None, optional): Logger instance (default: None).
             **kwargs: Arbitrary keyword arguments that may include:
                 - `headers` (Optional[Dict[str, str]])
@@ -56,7 +54,7 @@ class CadipClient(StacBase):
         super().__init__(
             rs_server_href,
             rs_server_api_key,
-            owner_id,
+            None,
             logger,
             get_href_service(rs_server_href, "RSPY_HOST_CADIP") + "/cadip/",
             **kwargs,

--- a/rs_client/catalog_client.py
+++ b/rs_client/catalog_client.py
@@ -16,7 +16,9 @@
 
 from __future__ import annotations
 
+import getpass
 import logging
+import re
 from collections.abc import Iterator
 
 import pystac
@@ -33,6 +35,16 @@ from rs_common.utils import get_href_service
 class CatalogClient(StacBase):  # type: ignore # pylint: disable=too-many-ancestors
     """CatalogClient inherits from both rs_client.RsClient and pystac_client.Client. The goal of this class is to
     allow an user to use RS-Server services more easily than calling REST endpoints directly.
+
+    Attributes:
+        owner_id (str): The owner of the STAC catalog collections (no special characters allowed).
+            If not set, we try to read it from the RSPY_HOST_USER environment variable. If still not set:
+            - In local mode, it takes the system username.
+            - In cluster mode, it is deduced from the API key or OAuth2 login = your keycloak username.
+            - In hybrid mode, we raise an Exception.
+            If owner_id is different than your keycloak username, then make sure that your keycloak account has
+            the rights to read/write on this catalog owner.
+            owner_id is also used in the RS-Client logging.
     """
 
     ##################
@@ -47,7 +59,18 @@ class CatalogClient(StacBase):  # type: ignore # pylint: disable=too-many-ancest
         logger: logging.Logger | None = None,
         **kwargs,
     ):
-        """CatalogClient class constructor."""
+        """CatalogClient class constructor.
+
+        Args:
+            rs_server_href (str | None): The URL of the RS-Server. Pass None for local mode.
+            rs_server_api_key (str | None, optional): API key for authentication (default: None).
+            owner_id (str | None, optional): ID of the catalog owner (default: None).
+            logger (logging.Logger | None, optional): Logger instance (default: None).
+
+        Raises:
+            RuntimeError: If neither an API key nor an OAuth2 cookie is provided for RS-Server authentication.
+            RuntimeError: If the computed owner ID is empty or contains only special characters.
+        """
         super().__init__(
             rs_server_href,
             rs_server_api_key,
@@ -56,6 +79,31 @@ class CatalogClient(StacBase):  # type: ignore # pylint: disable=too-many-ancest
             get_href_service(rs_server_href, "RSPY_HOST_CATALOG") + "/catalog/",
             **kwargs,
         )
+
+        # Determine automatically the owner id
+        if not self.owner_id:
+            # In local mode, we use the local system username
+            if self.local_mode:
+                self.owner_id = getpass.getuser()
+
+            # In hybrid mode, the API Key Manager check URL is not accessible and there is no OAuth2
+            # so the owner id must be set explicitly by the user.
+            elif self.hybrid_mode:
+                raise RuntimeError(
+                    "In hybrid mode, the owner_id must be set explicitly by parameter or environment variable",
+                )
+
+            # In cluster mode, we retrieve the OAuth2 or API key login
+            else:
+                self.owner_id = self.apikey_user_login if self.rs_server_api_key else self.oauth2_user_login
+
+        # Remove special characters
+        self.owner_id = re.sub(r"[^a-zA-Z0-9]+", "", self.owner_id)
+
+        if not self.owner_id:
+            raise RuntimeError("The owner ID is empty or only contains special characters")
+
+        self.logger.debug(f"Owner ID: {self.owner_id!r}")
 
     ##############
     # Properties #

--- a/rs_client/rs_client.py
+++ b/rs_client/rs_client.py
@@ -14,10 +14,8 @@
 
 """RsClient class implementation."""
 
-import getpass
 import logging
 import os
-import re
 import sys
 
 import requests
@@ -53,14 +51,7 @@ class RsClient:  # pylint: disable=too-many-instance-attributes
         rs_server_api_key (str | None): API key for RS-Server authentication.
         rs_server_oauth2_cookie (str | None): OAuth2 session cookie read from
             the `RSPY_OAUTH2_COOKIE` environment variable.
-        owner_id (str): The owner of the STAC catalog collections (no special characters allowed).
-            If not set, we try to read it from the RSPY_HOST_USER environment variable. If still not set:
-            - In local mode, it takes the system username.
-            - In cluster mode, it is deduced from the API key or OAuth2 login = your keycloak username.
-            - In hybrid mode, we raise an Exception.
-            If owner_id is different than your keycloak username, then make sure that your keycloak account has
-            the rights to read/write on this catalog owner.
-            owner_id is also used in the RS-Client logging.
+        owner_id (str | None): Only used in catalog client, see description there
         logger (logging.Logger): Logger instance for logging messages.
         local_mode (bool): Indicates whether the client is running in local mode.
         apikey_headers (dict): API key headers for HTTP requests.
@@ -85,7 +76,6 @@ class RsClient:  # pylint: disable=too-many-instance-attributes
 
         Raises:
             RuntimeError: If neither an API key nor an OAuth2 cookie is provided for RS-Server authentication.
-            RuntimeError: If the computed owner ID is empty or contains only special characters.
         """
         self.rs_server_href: str | None = rs_server_href
         self.rs_server_api_key: str | None = rs_server_api_key
@@ -117,31 +107,6 @@ class RsClient:  # pylint: disable=too-many-instance-attributes
         self.http_session = requests.Session()
         if self.rs_server_oauth2_cookie:
             self.http_session.cookies.set("session", self.rs_server_oauth2_cookie)
-
-        # Determine automatically the owner id
-        if not self.owner_id:
-            # In local mode, we use the local system username
-            if self.local_mode:
-                self.owner_id = getpass.getuser()
-
-            # In hybrid mode, the API Key Manager check URL is not accessible and there is no OAuth2
-            # so the owner id must be set explicitly by the user.
-            elif self.hybrid_mode:
-                raise RuntimeError(
-                    "In hybrid mode, the owner_id must be set explicitly by parameter or environment variable",
-                )
-
-            # In cluster mode, we retrieve the OAuth2 or API key login
-            else:
-                self.owner_id = self.apikey_user_login if self.rs_server_api_key else self.oauth2_user_login
-
-        # Remove special characters
-        self.owner_id = re.sub(r"[^a-zA-Z0-9]+", "", self.owner_id)
-
-        if not self.owner_id:
-            raise RuntimeError("The owner ID is empty or only contains special characters")
-
-        self.logger.debug(f"Owner ID: {self.owner_id!r}")
 
     def log_and_raise(self, message: str, original: Exception):
         """
@@ -263,7 +228,7 @@ class RsClient:  # pylint: disable=too-many-instance-attributes
             AuxipClient,
         )
 
-        return AuxipClient(self.rs_server_href, self.rs_server_api_key, self.owner_id, self.logger, **kwargs)
+        return AuxipClient(self.rs_server_href, self.rs_server_api_key, self.logger, **kwargs)
 
     def get_cadip_client(self, **kwargs) -> "CadipClient":  # type: ignore # noqa: F821
         """
@@ -273,7 +238,7 @@ class RsClient:  # pylint: disable=too-many-instance-attributes
             CadipClient,
         )
 
-        return CadipClient(self.rs_server_href, self.rs_server_api_key, self.owner_id, self.logger, **kwargs)
+        return CadipClient(self.rs_server_href, self.rs_server_api_key, self.logger, **kwargs)
 
     def get_catalog_client(self, **kwargs) -> "CatalogClient":  # type: ignore # noqa: F821
         """
@@ -299,4 +264,4 @@ class RsClient:  # pylint: disable=too-many-instance-attributes
             StagingClient,
         )
 
-        return StagingClient(self.rs_server_href, self.rs_server_api_key, self.owner_id, self.logger)
+        return StagingClient(self.rs_server_href, self.rs_server_api_key, None, self.logger)

--- a/rs_client/stac_base.py
+++ b/rs_client/stac_base.py
@@ -109,7 +109,7 @@ class StacBase(RsClient):
         # Initialize pystac_client.Client only if required (for CadipClient, AuxipClient, StacClient)
         if not stac_href:
             raise RuntimeError("No stac href provided")
-        # pystac_client may throw APIError exception this is handled bu the decorator handle_api_error
+        # pystac_client may throw APIError exception this is handled by the decorator handle_api_error
         self.stac_href = stac_href
         if rs_server_api_key:
             if headers is None:

--- a/rs_client/staging_client.py
+++ b/rs_client/staging_client.py
@@ -34,7 +34,7 @@ from stac_pydantic.api import Item, ItemCollection
 from rs_client.rs_client import TIMEOUT, RsClient
 from rs_common.utils import get_href_service
 
-# WARNING: this env variable is temporarily added until the response of rssrver-staging endpoints are corrected
+# WARNING: this env variable is temporarily added until the response of rs-server-staging endpoints are corrected
 # with a valid format according to ogc standard. In the meantime, we don't perform validation to make all staging
 # notebooks pass. If this env variable if not specified (for example that is the case when we launch the pytest),
 # we perform this validation by default

--- a/tests/test_catalog_client.py
+++ b/tests/test_catalog_client.py
@@ -13,17 +13,22 @@
 # limitations under the License.
 
 # pylint: disable=no-member
-"""All tests for the Stac Client."""
+"""All tests for the Stac Catalog Client."""
 
+import getpass
 import os
 from datetime import datetime
 
+import pytest
+import responses
 from pystac import Collection, Extent, Item, SpatialExtent, TemporalExtent
 
 from rs_client.catalog_client import CatalogClient
 from rs_client.rs_client import RsClient
+from tests.common import json_landing_page
 
-RS_SERVER_API_KEY = "RS_SERVER_API_KEY"
+from .conftest import RS_SERVER_API_KEY, RSPY_UAC_CHECK_URL
+
 OWNER_ID = "OWNER_ID"
 
 
@@ -253,3 +258,79 @@ def test_get_valid_item(mocked_stac_catalog_get_item):
 
     item = catalog.get_item("S1_L1", item_id, owner_id="toto")
     assert item.id == item_id
+
+
+@responses.activate
+@pytest.mark.parametrize("mode", ["local", "hybrid", "cluster"])
+def test_owner_id(mode, mocker, monkeypatch):  # pylint: disable=too-many-locals
+    """
+    Test different ways to set the owner_id, in local, hybrid and cluster mode.
+    """
+    local = mode == "local"
+    hybrid = mode == "hybrid"
+    cluster = mode == "cluster"
+
+    # Configure the mode. The server URL is set only in hybrid and cluster modes.
+    dummy_href = "https://DUMMY_HREF"
+    rs_server_href = None if local else dummy_href
+
+    # The uac manager url is set only in cluster mode
+    if cluster:
+        mocker.patch("rs_client.rs_client.RSPY_UAC_CHECK_URL", new=RSPY_UAC_CHECK_URL, autospec=False)
+
+    # Different owner_id values, depending on how it is set. Don't use special characters.
+    by_param = "param"
+    by_envvar = "envvar"
+    by_apikey = "apikey"
+    by_oauth2 = "oauth2"
+
+    # Error messages
+    error_auth = "API key or OAuth2 cookie is mandatory"
+    error_hybrid = "In hybrid mode, the owner_id must be set explicitly"
+
+    # If the owner_id is not set, in local mode, it takes the system username
+    if local:
+        local_href = "https://dummy-catalog"
+        monkeypatch.setenv("RSPY_HOST_CATALOG", local_href)
+        responses.get(url=f"{local_href}/catalog/", status=200, json=json_landing_page(local_href, "foo:bar"))
+        assert RsClient(rs_server_href).get_catalog_client().owner_id == getpass.getuser()
+    # In hybrid or cluster mode, we have an exception saying the apikey or oauth2 must be set
+    else:
+        responses.get(url=f"{rs_server_href}/catalog/", status=200, json=json_landing_page(dummy_href, "foo:bar"))
+        with pytest.raises(RuntimeError) as e:
+            RsClient(rs_server_href).get_catalog_client()
+        assert error_auth in str(e.value)
+
+    # Try setting owner_id from lowest to hight priority ways. It can be deduced from the oauth2.
+    monkeypatch.setenv("RSPY_OAUTH2_COOKIE", "RSPY_OAUTH2_COOKIE")
+    responses.get(url=f"{dummy_href}/auth/me", status=200, json={"user_login": by_oauth2, "iam_roles": []})
+    # In local mode we don't use neither apikey or oauth2
+    if local:
+        assert RsClient(rs_server_href).get_catalog_client().owner_id == getpass.getuser()
+    # In hybrid mode and don't use oauth2 and the URL to get api key info is unreachable
+    elif hybrid:
+        with pytest.raises(RuntimeError) as e:
+            RsClient(rs_server_href).get_catalog_client()
+        assert error_hybrid in str(e.value)
+    # In cluster mode we deduce the owner id from the oauth2 cookie
+    elif cluster:
+        assert RsClient(rs_server_href).get_catalog_client().owner_id == by_oauth2
+
+    # owner_id deduced from the API key has higher priority than from oauth2.
+    RsClient.apikey_security_cache.clear()
+    responses.get(url=RSPY_UAC_CHECK_URL, status=200, json={"user_login": by_apikey, "iam_roles": [], "config": {}})
+    if local:
+        assert RsClient(rs_server_href, RS_SERVER_API_KEY).get_catalog_client().owner_id == getpass.getuser()
+    elif hybrid:
+        with pytest.raises(RuntimeError) as e:
+            RsClient(rs_server_href, RS_SERVER_API_KEY).get_catalog_client()
+        assert error_hybrid in str(e.value)
+    elif cluster:
+        assert RsClient(rs_server_href, RS_SERVER_API_KEY).get_catalog_client().owner_id == by_apikey
+
+    # owner_id set by env var has higher priority than deduced from api key or oauth2
+    monkeypatch.setenv("RSPY_HOST_USER", by_envvar)
+    assert RsClient(rs_server_href, RS_SERVER_API_KEY).get_catalog_client().owner_id == by_envvar
+
+    # owner_id set by parameter has higher priority than all others
+    assert RsClient(rs_server_href, RS_SERVER_API_KEY, by_param).get_catalog_client().owner_id == by_param

--- a/tests/test_rs_client.py
+++ b/tests/test_rs_client.py
@@ -14,8 +14,6 @@
 
 """Unit tests for RsClient, AuxipClient, CadipClient."""
 
-import getpass
-
 import pytest
 import responses
 
@@ -23,6 +21,7 @@ from rs_client.auxip_client import AuxipClient
 from rs_client.cadip_client import CadipClient
 from rs_client.catalog_client import CatalogClient
 from rs_client.rs_client import RsClient
+from tests.common import json_landing_page
 
 from .conftest import RS_SERVER_API_KEY, RSPY_UAC_CHECK_URL
 
@@ -69,7 +68,8 @@ def test_apikey_security(mocker):
     assert rs_client.apikey_user_login == initial_response["user_login"]
 
     # Check that the owner id is taken from the apikey user login
-    assert rs_client.owner_id == initial_response["user_login"]
+    responses.get(url=f"{dummy_href}/catalog/", status=200, json=json_landing_page(dummy_href, "ownerid:collection_id"))
+    assert rs_client.get_catalog_client().owner_id == initial_response["user_login"]
 
     # If the UAC manager response changes, we won't see it because the previous result was cached
     modified_response = {
@@ -125,7 +125,8 @@ def test_oauth2_security(mocker, monkeypatch):
     assert rs_client.oauth2_user_login == auth_info["user_login"]
 
     # Check that the owner id is taken from the user login
-    assert rs_client.owner_id == auth_info["user_login"]
+    responses.get(url=f"{dummy_href}/catalog/", status=200, json=json_landing_page(dummy_href, "ownerid:collection_id"))
+    assert rs_client.get_catalog_client().owner_id == auth_info["user_login"]
 
 
 @pytest.mark.unit
@@ -137,78 +138,6 @@ def test_no_security():
 
     with pytest.raises(RuntimeError):
         RsClient(dummy_href)  # "API key or OAuth2 cookie is mandatory for RS-Server authentication"
-
-
-@responses.activate
-@pytest.mark.parametrize("mode", ["local", "hybrid", "cluster"])
-def test_owner_id(mode, mocker, monkeypatch):
-    """
-    Test different ways to set the owner_id, in local, hybrid and cluster mode.
-    """
-    local = mode == "local"
-    hybrid = mode == "hybrid"
-    cluster = mode == "cluster"
-
-    # Configure the mode. The server URL is set only in hybrid and cluster modes.
-    dummy_href = "https://DUMMY_HREF"
-    rs_server_href = None if local else dummy_href
-
-    # The uac manager url is set only in cluster mode
-    if cluster:
-        mocker.patch("rs_client.rs_client.RSPY_UAC_CHECK_URL", new=RSPY_UAC_CHECK_URL, autospec=False)
-
-    # Different owner_id values, depending on how it is set. Don't use special characters.
-    by_param = "param"
-    by_envvar = "envvar"
-    by_apikey = "apikey"
-    by_oauth2 = "oauth2"
-
-    # Error messages
-    error_auth = "API key or OAuth2 cookie is mandatory"
-    error_hybrid = "In hybrid mode, the owner_id must be set explicitly"
-
-    # If the owner_id is not set, in local mode, it takes the system username
-    if local:
-        assert RsClient(rs_server_href).owner_id == getpass.getuser()
-    # In hybrid or cluster mode, we have an exception saying the apikey or oauth2 must be set
-    else:
-        with pytest.raises(RuntimeError) as e:
-            RsClient(rs_server_href)
-        assert error_auth in str(e.value)
-
-    # Try setting owner_id from lowest to hight priority ways. It can be deduced from the oauth2.
-    monkeypatch.setenv("RSPY_OAUTH2_COOKIE", "RSPY_OAUTH2_COOKIE")
-    responses.get(url=f"{dummy_href}/auth/me", status=200, json={"user_login": by_oauth2, "iam_roles": []})
-    # In local mode we don't use neither apikey or oauth2
-    if local:
-        assert RsClient(rs_server_href).owner_id == getpass.getuser()
-    # In hybrid mode and don't use oauth2 and the URL to get api key info is unreachable
-    elif hybrid:
-        with pytest.raises(RuntimeError) as e:
-            RsClient(rs_server_href)
-        assert error_hybrid in str(e.value)
-    # In cluster mode we deduce the owner id from the oauth2 cookie
-    elif cluster:
-        assert RsClient(rs_server_href).owner_id == by_oauth2
-
-    # owner_id deduced from the API key has higher priority than from oauth2.
-    RsClient.apikey_security_cache.clear()
-    responses.get(url=RSPY_UAC_CHECK_URL, status=200, json={"user_login": by_apikey, "iam_roles": [], "config": {}})
-    if local:
-        assert RsClient(rs_server_href, RS_SERVER_API_KEY).owner_id == getpass.getuser()
-    elif hybrid:
-        with pytest.raises(RuntimeError) as e:
-            RsClient(rs_server_href, RS_SERVER_API_KEY)
-        assert error_hybrid in str(e.value)
-    elif cluster:
-        assert RsClient(rs_server_href, RS_SERVER_API_KEY).owner_id == by_apikey
-
-    # owner_id set by env var has higher priority than deduced from api key or oauth2
-    monkeypatch.setenv("RSPY_HOST_USER", by_envvar)
-    assert RsClient(rs_server_href, RS_SERVER_API_KEY).owner_id == by_envvar
-
-    # owner_id set by parameter has higher priority than all others
-    assert RsClient(rs_server_href, RS_SERVER_API_KEY, by_param).owner_id == by_param
 
 
 def test_log_and_raise_runtime_error(generic_rs_client, mocker):


### PR DESCRIPTION
Owner_id is only useful for catalog, move all the the validation logic in catalog client and erase completely this notion in AUXIP/CADIP clients.