### PR TITLE
RSPY-722 - Resolve conflicting json schema validation

### DIFF
--- a/config/staging_templates/yaml/inputValueNoObject.yaml
+++ b/config/staging_templates/yaml/inputValueNoObject.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oneOf:
+anyOf:
   - type: string
   - type: number
   - type: integer

--- a/rs_client/ogcapi/ogcapi_client.py
+++ b/rs_client/ogcapi/ogcapi_client.py
@@ -67,23 +67,23 @@ class OgcApiClient(RsClient):
             request (Request): endpoint request
 
         Returns:
-            ResponseUnmarshalResult.data: data validated by the openapi_core
+            RequestUnmarshalResult.data: data validated by the openapi_core
             unmarshal_response method
         """
         openapi_request = RequestsOpenAPIRequest(request)
 
-        # validate_request(request, spec=Spec.from_file_path(PATH_TO_YAML_OPENAPI))
+        # validate request
         result = self.get_openapi().unmarshal_request(openapi_request)
 
         if result.errors:
             raise OgcValidationException(
-                f"Error validating the request of the enpoint "
-                f"{openapi_request.path}: {str(result.errors[0])}",  # type: ignore
+                f"Error validating the request of the endpoint "
+                f"{openapi_request.path}: {', '.join(str(x) for x in result.errors)}",
             )
         if not result.body:
             raise OgcValidationException(
-                f"Error validating the request of the enpoint "
-                f"{openapi_request.path}: 'data' field of ResponseUnmarshalResult"
+                f"Error validating the request of the endpoint "
+                f"{openapi_request.path}: 'data' field of RequestUnmarshalResult"
                 f"object is empty",
             )
         return result.body
@@ -102,18 +102,17 @@ class OgcApiClient(RsClient):
         openapi_request = RequestsOpenAPIRequest(response.request)
         openapi_response = RequestsOpenAPIResponse(response)
 
-        # Alternative method to validate the response
-        # validate_response(response=response, spec= Spec.from_file_path(PATH_TO_YAML_OPENAPI), request=request)
+        # validate response
         result = self.get_openapi().unmarshal_response(openapi_request, openapi_response)  # type: ignore
         if result.errors:
             raise OgcValidationException(  # type: ignore
-                f"Error validating the response of the enpoint {openapi_request.path} - "
+                f"Error validating the response of the endpoint {openapi_request.path} - "
                 f"Server response content: {response.json()} - "
-                f"Validation error of the server response: {str(result.errors[0])}",  # type: ignore
+                f"Validation error of the server response: {', '.join(str(x) for x in result.errors)}",
             )
         if not result.data:
             raise OgcValidationException(
-                f"Error validating the response of the enpoint "
+                f"Error validating the response of the endpoint "
                 f"{openapi_request.path}: 'data' field of ResponseUnmarshalResult"
                 f"object is empty",
             )

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -176,6 +176,13 @@ def test_staging_ok(
     )
     assert staging_resp is not None
 
+    # Nominal case - problematic collection name in earlier version of json schema
+    staging_resp = staging_client.run_staging(
+        data_to_stage["features"][0],
+        "collection10",
+    )
+    assert staging_resp is not None
+
     # Nominal case - check that the test pass if the input data is a json file with a valid format
     item_file_to_stage = osp.join(RESOURCES_FOLDER, "staging", f"{station.lower()}_data.json")
     staging_resp = staging_client.run_staging(item_file_to_stage, OUTPUT_COLLECTION)


### PR DESCRIPTION
silly behaviour where some particular strings like "collection10" are both considered normal strings and binary strings (don't understand why). So I switched a "oneOf" to a "anyOf" (change already done in upstream repository, as a matter of fact).

All pull requests as we have these json schemas across multiple repositories:
https://github.com/RS-PYTHON/rs-client-libraries/pull/97
https://github.com/RS-PYTHON/rs-dpr-service/pull/18
https://github.com/RS-PYTHON/rs-server/pull/1403