### PR TITLE
Add missing env variable to allow staging PRIP products

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -465,7 +465,8 @@ def set_db_env_var_fixture(monkeypatch):
     envvars = {
         "RSPY_HOST_CATALOG": "https://dummy-catalog/catalog/",
         "RSPY_HOST_CADIP": "https://dummy-cadip/cadip/",
-        "RSPY_HOST_AUXIP": "https://dummy-audxip/auxip/",
+        "RSPY_HOST_AUXIP": "https://dummy-auxip/auxip/",
+        "RSPY_HOST_PRIP": "https://dummy-prip/prip/",
         "RSPY_HOST_STAGING": "https://dummy-staging/staging/",
     }
     for key, val in envvars.items():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,6 +48,7 @@ def test_get_href_service(
     rs_server_href = "https://dummy-rs-server-href/endpoint/"
     assert get_href_service(rs_server_href, "RSPY_HOST_CATALOG") == "https://dummy-catalog/catalog"
     assert get_href_service(rs_server_href, "RSPY_HOST_CADIP") == "https://dummy-cadip/cadip"
-    assert get_href_service(rs_server_href, "RSPY_HOST_AUXIP") == "https://dummy-audxip/auxip"
+    assert get_href_service(rs_server_href, "RSPY_HOST_AUXIP") == "https://dummy-auxip/auxip"
+    assert get_href_service(rs_server_href, "RSPY_HOST_PRIP") == "https://dummy-prip/prip"
     assert get_href_service(rs_server_href, "RSPY_HOST_STAGING") == "https://dummy-staging/staging"
     assert get_href_service(rs_server_href, "RSPY_HOST_UNKNWON") == rs_server_href.rstrip("/")


### PR DESCRIPTION
Fixes to allow to stage PRIP products:

- https://github.com/RS-PYTHON/rs-server/pull/1531
- https://github.com/RS-PYTHON/rs-client-libraries/pull/134
- https://github.com/RS-PYTHON/rs-demo/pull/200
- https://github.com/RS-PYTHON/rs-helm/pull/168