### PR TITLE
Remove monitoring stack in local mode

### DIFF
--- a/rs_common/prefect_utils.py
+++ b/rs_common/prefect_utils.py
@@ -192,7 +192,6 @@ async def init_prefect_blocks():
             "POSTGRES_PORT",
             "POSTGRES_PI_DB",
             "POSTGRES_HOST",
-            "TEMPO_ENDPOINT",
             *dask_gateway_vars,
             "LOCAL_DASK_USERNAME",
             "LOCAL_DASK_PASSWORD",

--- a/tests/test_prefect_utils.py
+++ b/tests/test_prefect_utils.py
@@ -88,7 +88,6 @@ async def test_init_prefect_blocks(monkeypatch, mock_prefect, local_mode):  # py
         "POSTGRES_HOST": "test_host",
         "POSTGRES_PORT": "5432",
         "POSTGRES_PI_DB": "test_db",
-        "TEMPO_ENDPOINT": "TEMPO_ENDPOINT",
         "DASK_GATEWAY_ADDRESS": "DASK_GATEWAY_ADDRESS",
         "LOCAL_DASK_USERNAME": "LOCAL_DASK_USERNAME",
         "LOCAL_DASK_PASSWORD": "LOCAL_DASK_PASSWORD",
@@ -101,6 +100,7 @@ async def test_init_prefect_blocks(monkeypatch, mock_prefect, local_mode):  # py
 
     # In cluster mode, they must be set in a prefect block
     else:
+        env_global["TEMPO_ENDPOINT"] = "TEMPO_ENDPOINT"
         await Secret(value=env_global).save(  # type: ignore[arg-type]
             prefect_utils.BLOCK_NAME_ENV_GLOBAL,
             overwrite=True,


### PR DESCRIPTION
It is almost unused, not updated, not representative of cluster mode with the lack of Alloy:

- https://github.com/RS-PYTHON/rs-demo/pull/240
- https://github.com/RS-PYTHON/rs-client-libraries/pull/183
- https://github.com/RS-PYTHON/rs-server/pull/1722
- https://github.com/RS-PYTHON/rs-dpr-service/pull/65