### PR TITLE
Document DPR processing flow inputs as per specification

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -16,6 +16,10 @@ name: Check code quality
 
 on:
   push:
+    branches:
+      - develop # pushes on the 'develop' branch
+    tags:
+      - '**' # new git tags (including hierarchical tags like v1.0/beta)
   pull_request:
     types: [opened, synchronize, reopened]
     # run this worflow only for code/test related changes (avoid it for documentation)

--- a/rs_client/ogcapi/dpr_client.py
+++ b/rs_client/ogcapi/dpr_client.py
@@ -44,10 +44,18 @@ class DprProcessor(str, Enum):
     """DPR processor name"""
 
     # String value = resource name in the rs-dpr-service
-    MOCKUP = "mockup"
     S1L0 = "s1_l0"
     S3L0 = "s3_l0"
     S1ARD = "s1_ard"
+
+
+class DprPipeline(str, Enum):
+    """DPR pipeline name"""
+
+    # String value = resource name in the rs-dpr-service
+    S1L0FULL = "s1_l0_full"
+    S3L0FULL = "s3_l0_full"
+    S1ARDFULL = "s1_ard_full"
 
 
 @dataclass
@@ -108,7 +116,7 @@ class DprClient(OgcApiClient):
 
     def run_process(
         self,
-        process: DprProcessor,
+        process: str,
         cluster_info: ClusterInfo,
         s3_config_dir: str,
         payload_subpath: str,
@@ -118,7 +126,7 @@ class DprClient(OgcApiClient):
         """Method to start the process from rs-client - Call the endpoint /processes/{process}/execution
 
         Args:
-            process: DPR process
+            process: DPR process name
             cluster_info: Information to connect to a DPR Dask cluster
             s3_config_dir: S3 bucket folder that contains the payload and configuration files to pass to the processor
             payload_subpath: Payload file path, relative to the config folder
@@ -131,7 +139,7 @@ class DprClient(OgcApiClient):
             (or None if endpoint fails) of the running job
         """
 
-        use_mockup = process == DprProcessor.MOCKUP
+        use_mockup = process.lower() == "mockup"
 
         # Data to pass to the real processor
         data = {}
@@ -163,7 +171,7 @@ class DprClient(OgcApiClient):
         data.update(asdict(cluster_info))
 
         # Call the parent method
-        return super()._run_process(process.value, data)
+        return super()._run_process(process, data)
 
     def run_conv_safe_zarr(self, payload: dict, cluster_info: ClusterInfo):
         """Method to start the safe to zarr conversion process from rs-client -

--- a/rs_workflows/dpr_flow.py
+++ b/rs_workflows/dpr_flow.py
@@ -109,7 +109,7 @@ def create_stac_item(
     eopf_feature,
     s3_data_location,
     product_name: str,
-    dpr_processor: DprProcessor,
+    dpr_processor: str,
 ) -> Item:
     """
     Create a list of STAC Items from EOPF features and processing payload metadata.
@@ -122,12 +122,14 @@ def create_stac_item(
     Args:
         eopf_features (list[dict]): List of GeoJSON-like feature dictionaries.
         s3_data_location (str): Base S3 path where output products are stored.
+        product_name (str): Product name
+        dpr_processor (str): DPR processor name
 
     Returns:
         list[Item]: List of constructed STAC Item objects.
     """
 
-    def build_item(feature_dict: dict, eopf_origin_datetimes, product_name, dpr_processor: DprProcessor) -> Item:
+    def build_item(feature_dict: dict, eopf_origin_datetimes, product_name, dpr_processor: str) -> Item:
         """
         Build a STAC Item from a feature dictionary.
 
@@ -153,7 +155,7 @@ def create_stac_item(
         # - do not set stac_extension SAR for Sentinel-3 products "with instrument different from SRAL"
         # Get in line with the story once clarified !
         stac_extensions: list[str] = []
-        if dpr_processor == DprProcessor.S1L0:
+        if dpr_processor == DprProcessor.S1L0.value:
             stac_extensions = [
                 # TODO: We don't include the full list for now to avoid issues with catalog ingestion
                 # This is because some extensions may require specific properties that are not properly
@@ -205,7 +207,7 @@ def create_stac_item(
     # C1.1 Add the property eopf:origin_datetime with value equal to the maximum
     # eopf:origin_datetime among all input products (excluding ADFS inputs)
     # Note: input_products != input_adfs
-    eopf_origin_datetime = compute_eopf_origin_datetime(env, input_products, dpr_processor)
+    eopf_origin_datetime = compute_eopf_origin_datetime(env, input_products)
 
     item = build_item(eopf_feature, eopf_origin_datetime, product_name, dpr_processor)
     item.assets = {product_name: build_asset(s3_data_location, product_name)}
@@ -218,7 +220,7 @@ def update_eopf_assets(
     env,
     input_products: list[dict],
     payload: dict,
-    dpr_processor: DprProcessor,
+    dpr_processor: str,
 ) -> tuple[Any, Any]:
     """
     Update EOPF-related STAC assets by discovering products in S3 and
@@ -248,6 +250,8 @@ def update_eopf_assets(
     payload : dict
         Workflow payload containing input/output definitions. The S3 discovery
         path is read from ``payload["I/O"]["output_products"]``.
+    dpr_processor: str
+        DPR processor name
 
     Returns
     -------
@@ -304,12 +308,12 @@ def update_eopf_assets(
     return stac_items, eopf_types
 
 
-def compute_eopf_origin_datetime(env, input_products, dpr_processor: DprProcessor) -> str:
+def compute_eopf_origin_datetime(env, input_products) -> str:
     """
-    Compute the maximum ``eopf:origin_datetime`` across all input CADU products.
+    Compute the maximum ``eopf:origin_datetime`` across all input products.
 
     For each input product, this function retrieves the corresponding item
-    from the catalog using its CADU ID and collection ID, extracts the
+    from the catalog using its item ID and collection ID, extracts the
     ``eopf:origin_datetime`` property, and returns the latest (maximum)
     datetime value found.
 
@@ -323,7 +327,7 @@ def compute_eopf_origin_datetime(env, input_products, dpr_processor: DprProcesso
         to the catalog flow.
     input_products : Iterable[dict]
         Iterable of input product mappings. Each mapping is expected to
-        contain values of the form ``(cadu_id, collection_id)``.
+        contain values of the form ``(item_id, collection_id)``.
 
     Returns
     -------
@@ -333,36 +337,33 @@ def compute_eopf_origin_datetime(env, input_products, dpr_processor: DprProcesso
         returns the fallback value ``"2023-01-01T00:00:00Z"``.
     """
     logger = get_run_logger()
-    cadu_items = []
-    if dpr_processor == DprProcessor.MOCKUP:
-        logger.info("Mockup processor detected, using fixed eopf:origin_datetime value.")
-        return "2023-01-01T00:00:00Z"
+    items = []
 
     for input_product in input_products:
-        for _, (cadu_id, collection_id) in input_product.items():
+        for _, (item_id, collection_id) in input_product.items():
             try:
                 future = catalog_flow.get_item.submit(
                     env.serialize(),
                     collection_id,
-                    cadu_id,
+                    item_id,
                 )
-                cadu_items.append(future.result())
+                items.append(future.result())
             except RuntimeError as rte:
-                logger.exception(f"Failed to get CADU item '{cadu_id}' from collection '{collection_id}'")
-                raise RuntimeError("No valid CADU items found to compute eopf:origin_datetime") from rte
+                logger.exception(f"Failed to get item '{item_id}' from collection '{collection_id}'")
+                raise RuntimeError("No valid items found to compute eopf:origin_datetime") from rte
 
-    logger.info(f"Items matching input found in catalog: {len(cadu_items)}")
+    logger.info(f"Items matching input found in catalog: {len(items)}")
 
-    if not cadu_items:
+    if not items:
         # error maybe?
-        logger.error("No valid CADU items found to compute eopf:origin_datetime. Exit")
-        raise RuntimeError("No valid CADU items found to compute eopf:origin_datetime")
+        logger.error("No valid items found to compute eopf:origin_datetime. Exit")
+        raise RuntimeError("No valid items found to compute eopf:origin_datetime")
 
     max_eopf_datetime = max(
         datetime.datetime.fromisoformat(
             item.to_dict()["properties"]["eopf:origin_datetime"].replace("Z", "+00:00"),  # type: ignore
         )
-        for item in cadu_items
+        for item in items
     ).isoformat()
 
     logger.info(f"Maximum eopf datetime computed from all items is {max_eopf_datetime}")
@@ -372,7 +373,7 @@ def compute_eopf_origin_datetime(env, input_products, dpr_processor: DprProcesso
 @task(name="Run DPR processor")
 async def run_processor(
     env: FlowEnvArgs,
-    processor: DprProcessor,
+    processor: str,
     payload: dict,
     cluster_info: ClusterInfo,
     s3_payload_run: str,
@@ -396,7 +397,7 @@ async def run_processor(
             status="OK",
             dpr_processing_input_stac_items=s3_payload_run,
             payload=payload,
-            dpr_processor_name=processor.value,
+            dpr_processor_name=processor,
         )
         # Trigger the processor run from the dpr service
         dpr_client: DprClient = flow_env.rs_client.get_dpr_client()
@@ -407,7 +408,7 @@ async def run_processor(
             payload_subpath=osp.basename(s3_payload_run),
             s3_report_dir=osp.join(osp.dirname(s3_payload_run)),
         )
-        dpr_client.wait_for_job(job_status, logger, f"{processor.value!r} processor")
+        dpr_client.wait_for_job(job_status, logger, f"{processor!r} processor")
 
         eopf_stac_items, eopf_types = update_eopf_assets(flow_env, input_products, payload, processor)
         # Wait for the job to finish

--- a/rs_workflows/flow_utils.py
+++ b/rs_workflows/flow_utils.py
@@ -24,9 +24,10 @@ from opentelemetry import trace
 from opentelemetry.trace import Span, SpanContext
 from opentelemetry.util._decorator import _agnosticcontextmanager
 from prefect import get_run_logger
+from pydantic import BaseModel, Field, field_validator, model_validator
 from pystac import Item
 
-from rs_client.ogcapi.dpr_client import DprProcessor
+from rs_client.ogcapi.dpr_client import DprPipeline, DprProcessor
 from rs_client.rs_client import RsClient
 from rs_common import init_opentelemetry, prefect_utils
 
@@ -63,8 +64,21 @@ class ProcessingMode(str, Enum):
     ALWAYS = "always"
 
 
-@dataclass
-class FlowEnvArgs:
+class SentinelSatellite(str, Enum):
+    """Sentinel satellite name"""
+
+    # String value = STAC standardized value
+    S1A = "sentinel-1a"
+    S1B = "sentinel-1b"
+    S1C = "sentinel-1c"
+    S2A = "sentinel-2a"
+    S2B = "sentinel-2b"
+    S2C = "sentinel-2c"
+    S3A = "sentinel-3a"
+    S3B = "sentinel-3b"
+
+
+class FlowEnvArgs(BaseModel):
     """
     Prefect flow environment arguments.
 
@@ -75,8 +89,13 @@ class FlowEnvArgs:
         calling_span (tuple): Serialized OpenTelemetry span of the calling flow, if any.
     """
 
-    owner_id: str
-    calling_span: tuple[int, int, bool] | None = None
+    owner_id: str = Field(
+        description="User/owner ID (necessary to retrieve the user info) from the right Prefect block",
+    )
+    calling_span: tuple[int, int, bool] | None = Field(
+        default=None,
+        description="Serialized OpenTelemetry span of the calling flow, if any",
+    )
 
 
 class FlowEnv:
@@ -155,48 +174,142 @@ class FlowEnv:
             yield span
 
 
-@dataclass
-class DprProcessIn:  # pylint: disable=too-many-instance-attributes
+class DprProcessIn(BaseModel):  # pylint: disable=too-many-instance-attributes
     """
     Input parameters for the 'dpr-process' flow
+
+    Attributes:
+        env: Prefect flow environment
+        processor_name: DPR processor name
+        processor_version: DPR processor version
+        dask_cluster_label: Dask cluster label e.g. "dask-l0"
+        s3_payload_file: S3 path where the processor payload will be written
+        pipeline: Processor pipeline name. The task table propose one or several pipelines.
+          Mandatory if unit is not provided.
+        unit: Processor unit name. Advanced users can call directly a single unit of the task table.
+          Mandatory if pipeline is not provided.
+        priority: Priority for the cluster dask to be able to prioritise task execution. By default is "low".
+        workflow_type: Workflow type (benchmarking, on-demand, systematic). By default is "on-demand".
+        input_products: List of input products for the processor, structured as follows:
+          * input_products.name
+          * (stac item identifier, collection name)
+          Example: [( "S1CADUS", ["S1A1234", "s01-cadip-session"])]
+        generated_product_to_collection_identifier: List of output products for the processor, structured as follows:
+          * output_products.name
+          * (product:type, collection name)
+          or
+          * product:type
+          When the collection name is not specified, it is equal to product:type.
+          Example: [( "SRAL0", "s03sral0_" ),( "MWRL0", "s03mwrl0", "my-collection" )]
+        auxiliary_product_to_collection_identifier: Collection name where to push each auxiliary file (in rs-catalog).
+          To apply the same treatment to all product types simultaneously, a "*" wildcard can be used.
+          By default (when no input is provided), the collection name is set to <mission>-aux-<product:type>
+        processing_mode: List of modes to be applied when calling the DPR processor.
+        start_datetime: Date that can be used to retrieve auxiliary data on the right time frame.
+        end_datetime: Date that can be used to retrieve auxiliary data on the right time frame.
+        satellite: In certain CQL2 queries from task tables, the <satellite> parameter must be provided,
+          as some auxiliary files depend on the satellite.
     """
 
-    env: FlowEnvArgs
-    processor_name: DprProcessor
-    processor_version: str
-    dask_cluster_label: str
-    s3_payload_file: str
+    env: FlowEnvArgs = Field(description="Prefect flow environment")
+    processor_name: DprProcessor | str = Field(description="DPR processor name")
+    processor_version: str = Field(description="DPR processor version")
+    dask_cluster_label: str = Field(description='Dask cluster label e.g. "dask-l0"')
+    s3_payload_file: str = Field(description="S3 path where the processor payload will be written")
     # 'pipeline' or 'unit' must be provided
-    pipeline: str | None = None
-    unit: str | None = None
+    pipeline: DprPipeline | str | None = Field(
+        default=None,
+        description="Processor pipeline name. The task table propose one or several pipelines. "
+        "Mandatory if unit is not provided.",
+    )
+    unit: str | None = Field(
+        default=None,
+        description="Processor unit name. Advanced users can call directly a single unit of the task table. "
+        "Mandatory if pipeline is not provided.",
+    )
 
-    priority: Priority = Priority.LOW
-    workflow_type: WorkflowType = WorkflowType.ON_DEMAND
+    priority: Priority = Field(
+        default=Priority.LOW,
+        description="Priority for the cluster dask to be able to prioritise task execution. Default: `low`.",
+    )
+    workflow_type: WorkflowType = Field(
+        default=WorkflowType.ON_DEMAND,
+        description="Workflow type (benchmarking, on-demand, systematic). Default: `on-demand`.",
+    )
 
-    input_products: list[dict[str, tuple[str, str]]] = field(default_factory=list)
-    generated_product_to_collection_identifier: list[dict[str, str | tuple[str, str]]] = field(default_factory=list)
-    auxiliary_product_to_collection_identifier: dict[str, str] = field(default_factory=dict)
+    input_products: list[dict[str, tuple[str, str]]] = Field(
+        description="List of input products for the processor, structured as follows: "
+        "`input_products.name, (stac item identifier, collection name)`. "
+        'Example: `[( "S1CADUS", ["S1A1234", "s01-cadip-session"])]`',
+    )
+    generated_product_to_collection_identifier: list[dict[str, str | tuple[str, str]]] = Field(
+        description="List of output products for the processor, structured as follows: "
+        "`output_products.name, (product:type, collection name)` "
+        "or "
+        "`product:type`. "
+        "When the collection name is not specified, it is equal to `product:type`. "
+        'Example: `[( "SRAL0", "s03sral0_" ),( "MWRL0", "s03mwrl0", "my-collection" )]`',
+    )
+    auxiliary_product_to_collection_identifier: dict[str, str] = Field(
+        default_factory=dict,
+        description="Collection name where to push each auxiliary file (in rs-catalog). "
+        "To apply the same treatment to all product types simultaneously, a `*` wildcard can be used. "
+        "By default (when no input is provided), the collection name is set to `<mission>-aux-<product:type>`",
+    )
 
-    processing_mode: list[ProcessingMode] = field(default_factory=list)
-    start_datetime: datetime | None = None
-    end_datetime: datetime | None = None
-    satellite: str | None = None
+    processing_mode: list[ProcessingMode] = Field(
+        default_factory=list,
+        description="List of modes to be applied when calling the DPR processor.",
+    )
+    start_datetime: datetime | None = Field(
+        default=None,
+        description="Date that can be used to retrieve auxiliary data on the right time frame.",
+    )
+    end_datetime: datetime | None = Field(
+        default=None,
+        description="Date that can be used to retrieve auxiliary data on the right time frame.",
+    )
+    satellite: SentinelSatellite | str | None = Field(
+        default=None,
+        description="In certain CQL2 queries from task tables, the `<satellite>` parameter must be provided, "
+        "as some auxiliary files depend on the satellite.",
+    )
 
-    def __post_init__(self) -> None:
-        # Enforce the "pipeline XOR unit" rule
+    @field_validator("processor_name", mode="before")
+    @classmethod
+    def normalize_processor_name(cls, v):
+        """Normalize the processor name to a string."""
+        return v.value if isinstance(v, DprProcessor) else v
+
+    @field_validator("satellite", mode="before")
+    @classmethod
+    def normalize_satellite_name(cls, v):
+        """Normalize the satellite name to a string."""
+        return v.value if isinstance(v, SentinelSatellite) else v
+
+    @model_validator(mode="after")
+    def check_model(self):
+        """
+        Ensure required inputs are not empty and that exactly one of 'pipeline' or 'unit' is provided.
+
+        The caller must specify either a pipeline or a unit, but not both
+        and not neither.
+        """
         has_pipeline = bool(self.pipeline)
         has_unit = bool(self.unit)
         if has_pipeline == has_unit:
             raise ValueError("Exactly one of 'pipeline' or 'unit' must be provided.")
 
-        # if not self.input_products:
-        #    raise ValueError("'input_products' must contain at least one pystac.Item.")
+        if not self.input_products:
+            raise ValueError("'input_products' must contain at least one pystac.Item.")
 
         if not self.generated_product_to_collection_identifier:
             raise ValueError("'generated_product_to_collection_identifier' must not be empty.")
 
         if not self.auxiliary_product_to_collection_identifier:
             raise ValueError("'auxiliary_product_to_collection_identifier' must not be empty.")
+
+        return self
 
 
 @dataclass

--- a/rs_workflows/on_demand_processing.py
+++ b/rs_workflows/on_demand_processing.py
@@ -24,6 +24,7 @@ import anyio
 import yaml
 from prefect import flow, get_run_logger, task
 from prefect.artifacts import acreate_markdown_artifact
+from starlette.status import HTTP_400_BAD_REQUEST
 
 from rs_client.ogcapi.dpr_client import ClusterInfo
 from rs_common import prefect_utils
@@ -94,19 +95,10 @@ async def dpr_processing(
     Prefect flow for dpr-process.
 
     Args:
-        env: Prefect flow environment
-        processor: DPR processor name
-        cluster_label (str): Dask cluster label e.g. "dask-l0"
-        cadip_collection_identifier: CADIP collection identifier that contains the mission and station
-            (e.g. s1_ins for Sentinel-1 sessions from the Inuvik station)
-        session_identifier: Session identifier
-        catalog_collection_identifier: Catalog collection identifier where CADIP sessions and AUX data are staged
-        s3_payload_template: S3 bucket location of the DPR payload file template.
-        s3_output_data: S3 bucket location of the output processed products. They will then be copied to the
-        catalog bucket.
+        dpr_input: Processing request inputs
     """
     logger = get_run_logger()
-    logger.info(f"Starting the DPR processing flow with processor: {dpr_input.processor_name.value}")
+    logger.info(f"Starting the DPR processing flow with processor: {dpr_input.processor_name}")
     # Init flow environment and opentelemetry span
     flow_env = FlowEnv(dpr_input.env)
 
@@ -120,7 +112,10 @@ async def dpr_processing(
         )
 
         # read tasktable and construct list of processing units
-        task_table = flow_env.rs_client.get_dpr_client().get_process(dpr_input.processor_name.value, cluster_info)
+        process_resp = flow_env.rs_client.get_dpr_client().get_process(dpr_input.processor_name, cluster_info)
+        if "status" in process_resp and int(process_resp["status"]) >= HTTP_400_BAD_REQUEST:
+            raise ValueError(f"Could not retrieve task table for process '{dpr_input.processor_name}': {process_resp}")
+        task_table = process_resp
         processing_mode = list(dpr_input.processing_mode) if dpr_input.processing_mode else None
         out = build_unit_list(
             tasktable=task_table,

--- a/rs_workflows/payload_builder.py
+++ b/rs_workflows/payload_builder.py
@@ -164,13 +164,13 @@ def build_unit_list(
     """
     # Validate pipelines shape
     if not isinstance(tasktable, dict):
-        raise TaskTableError("Task table root must be a JSON object (dict).")
+        raise TaskTableError(f"Task table root must be a JSON object (dict): {tasktable}")
     if "pipelines" not in tasktable or not isinstance(tasktable["pipelines"], list):
-        raise TaskTableError('Missing or invalid "pipelines" list in task table.')
+        raise TaskTableError(f"Missing or invalid 'pipelines' list in task table: {tasktable}")
     if "units" not in tasktable or not isinstance(tasktable["units"], list):
-        raise TaskTableError('Missing or invalid "units" list in task table.')
+        raise TaskTableError(f"Missing or invalid 'units' list in task table: {tasktable}")
     if "io" not in tasktable or not isinstance(tasktable["io"], list):
-        raise TaskTableError('Missing or invalid "io" list in task table.')
+        raise TaskTableError(f"Missing or invalid 'io' list in task table: {tasktable}")
 
     # Build indices for quick lookup
     units_index: dict[str, dict[str, Any]] = {}

--- a/rs_workflows/payload_generator.py
+++ b/rs_workflows/payload_generator.py
@@ -621,7 +621,7 @@ def generate_payload(  # pylint: disable=unused-argument
     # The storage_configuration.json file should be mounted in /etc/storage_configuration.json
     # in cluster mode, it should be mounted as volume from a predefined (?) configmap
 
-    if dpr_process_in.processor_name == DprProcessor.MOCKUP:
+    if dpr_process_in.processor_name.lower() == "mockup":
         logger.info("Generating payload for mockup processor")
         # TODO: the ouput path can be also computed, by using the following 3 lines
         # and add output_mockup_path as param to build_mockup_payload
@@ -630,7 +630,7 @@ def generate_payload(  # pylint: disable=unused-argument
         # output_mockup_path=build_output_products(unit_list[0], dpr_process_in, store_params, flow_env, config_rows)
         return build_mockup_payload(flow_env.owner_id)
 
-    logger.info(f"Starting payload generation for DPR processor '{dpr_process_in.processor_name.value}'")
+    logger.info(f"Starting payload generation for DPR processor '{dpr_process_in.processor_name}'")
     logger.info("Loading storage configuration template from file")
     secrets = Secret.load(
         prefect_utils.format_env_user(prefect_utils.BLOCK_NAME_ENV_USER, flow_env.owner_id),

--- a/tests/test_dpr.py
+++ b/tests/test_dpr.py
@@ -79,14 +79,14 @@ def get_dpr_response_sample() -> dict:
 
 
 @responses.activate
-@pytest.mark.parametrize("process", [DprProcessor.MOCKUP, DprProcessor.S1L0])
-def test_dpr_client(mocker, dpr_client: DprClient, process: DprProcessor, dummy_href: str, dpr_response_sample: dict):
+@pytest.mark.parametrize("process", ["mockup", DprProcessor.S1L0.value])
+def test_dpr_client(mocker, dpr_client: DprClient, process: str, dummy_href: str, dpr_response_sample: dict):
     """Test nominal DPR service response"""
 
     # Mock response from DPR service
     responses.add(
         method=responses.POST,
-        url=f"{dummy_href}/dpr/processes/{process.value}/execution",
+        url=f"{dummy_href}/dpr/processes/{process}/execution",
         json=dpr_response_sample,
         status=status.HTTP_200_OK,
     )

--- a/tests/test_dpr_flow_helper.py
+++ b/tests/test_dpr_flow_helper.py
@@ -347,7 +347,7 @@ def test_compute_eopf_origin_datetime_single_item(mocker):
         return_value=mock_future,
     )
 
-    result = compute_eopf_origin_datetime(env, input_products, DprProcessor.S1L0)
+    result = compute_eopf_origin_datetime(env, input_products)
 
     assert result == "2024-01-10T12:00:00+00:00"
 
@@ -385,7 +385,7 @@ def test_compute_eopf_origin_datetime_multiple_items_returns_max(mocker):
         side_effect=[future_1, future_2],
     )
 
-    result = compute_eopf_origin_datetime(env, input_products, DprProcessor.S1L0)
+    result = compute_eopf_origin_datetime(env, input_products)
 
     assert result == "2024-02-01T00:00:00+00:00"
 
@@ -414,6 +414,6 @@ def test_compute_eopf_origin_datetime_raises_on_catalog_error(mocker):
 
     with pytest.raises(
         RuntimeError,
-        match="No valid CADU items found to compute eopf:origin_datetime",
+        match="No valid items found to compute eopf:origin_datetime",
     ):
-        compute_eopf_origin_datetime(env, input_products, DprProcessor.S1L0)
+        compute_eopf_origin_datetime(env, input_products)

--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -145,7 +145,7 @@ def test_build_unit_list_requires_one_of_pipeline_or_unit():
 
 def test_build_unit_list_invalid_tasktable_root_type():
     """Test that providing a non-dict task table raises TaskTableError with the expected message."""
-    with pytest.raises(TaskTableError, match=r"Task table root must be a JSON object \(dict\)\."):
+    with pytest.raises(TaskTableError, match=r"Task table root must be a JSON object \(dict\):.+"):
         build_unit_list("not a dict", pipeline="p1")  # type: ignore[arg-type]
 
 
@@ -153,7 +153,7 @@ def test_build_unit_list_missing_or_invalid_pipelines_list():
     """Test that a missing or non-list 'pipelines' field in the task table raises
     TaskTableError with the expected message."""
     tt: dict[str, Any] = {"units": [], "io": []}
-    with pytest.raises(TaskTableError, match='Missing or invalid "pipelines" list in task table\\.'):
+    with pytest.raises(TaskTableError, match=r"Missing or invalid 'pipelines' list in task table:.+"):
         build_unit_list(tt, pipeline="p1")
 
 
@@ -161,7 +161,7 @@ def test_build_unit_list_missing_or_invalid_units_list():
     """Test that a missing or non-list 'units' field in the task table raises
     TaskTableError with the expected message."""
     tt: dict[str, Any] = {"pipelines": [], "io": []}
-    with pytest.raises(TaskTableError, match='Missing or invalid "units" list in task table\\.'):
+    with pytest.raises(TaskTableError, match=r"Missing or invalid 'units' list in task table:.+"):
         build_unit_list(tt, pipeline="p1")
 
 
@@ -171,7 +171,7 @@ def test_build_unit_list_missing_or_invalid_io_list():
         "pipelines": [{"name": "p1", "steps": [{"order": 1, "unit_name": "u1"}]}],
         "units": [{"name": "u1", "module": "m", "input_products": [], "input_adfs": [], "output_products": []}],
     }
-    with pytest.raises(TaskTableError, match='Missing or invalid "io" list in task table\\.'):
+    with pytest.raises(TaskTableError, match=r"Missing or invalid 'io' list in task table:.+"):
         build_unit_list(tt, pipeline="p1")
 
 

--- a/tests/test_payload_generator.py
+++ b/tests/test_payload_generator.py
@@ -285,7 +285,7 @@ def test_generate_payload_mockup_processor(flow_env, mock_dpr_process_in):
     """
     Test the special MOCKUP processor path returns a valid mock payload.
     """
-    mock_dpr_process_in.processor_name = DprProcessor.MOCKUP
+    mock_dpr_process_in.processor_name = "MOCKUP"
     payload = generate_payload.fn(
         flow_env=flow_env,
         unit_list=[],

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -26,7 +26,6 @@ from prefect.blocks.system import Secret
 from pydantic import SecretStr
 from pystac import Asset, Item, ItemCollection
 
-from rs_client.ogcapi.dpr_client import DprProcessor
 from rs_client.rs_client import RsClient
 from rs_common import prefect_utils
 from rs_workflows import (
@@ -355,7 +354,7 @@ async def test_dpr_processing(
     # build realistic input
     dpr_input = DprProcessIn(
         env=FlowEnvArgs(owner_id=OWNER_ID),
-        processor_name=DprProcessor.MOCKUP,
+        processor_name="mockup",
         processor_version="1.0",
         pipeline="mockup_full",
         dask_cluster_label="cluster_label",
@@ -421,7 +420,7 @@ async def test_dpr_processing_raises_on_unstaged_adf(
 
     dpr_input = DprProcessIn(
         env=FlowEnvArgs(owner_id=OWNER_ID),
-        processor_name=DprProcessor.MOCKUP,
+        processor_name="mockup",
         processor_version="1.0",
         pipeline="mockup_full",
         dask_cluster_label="cluster_label",


### PR DESCRIPTION
Document fields correctly in order to have their description in Prefect UI.

Changed `DprProcessIn` and `FlowEnvArgs` from a dataclass to a Pydantic model, couldn't make it work correctly in Prefect otherwise. It seems Prefect has only proper support of Pydantic models, not dataclasses, see https://docs.prefect.io/v3/advanced/form-building

Remove `MOCKUP` from the UI, this must not be displayed to end users.

Make input products mandatory again, processing without inputs makes no sense.

Enforce the computation of `eopf:origin_datetime` for all processors. The mockup goal is not to short-circuit our own algorithms.

Needs https://github.com/RS-PYTHON/rs-demo/pull/251

**Before:**

<img width="1865" height="994" alt="Screenshot 2026-02-11 at 10-34-26 Create Flow Run for Deployment DPR processing • Prefect Server" src="https://github.com/user-attachments/assets/321844d1-e39f-4b87-a1fa-b4010c597b4c" />
<img width="1865" height="994" alt="Screenshot 2026-02-11 at 10-34-39 Create Flow Run for Deployment DPR processing • Prefect Server" src="https://github.com/user-attachments/assets/a620161a-edaa-44f1-b231-76e59cc0e873" />

**After:**

<img width="1865" height="994" alt="Screenshot 2026-02-11 at 10-35-45 Create Flow Run for Deployment DPR Processing Vincent • Prefect Server" src="https://github.com/user-attachments/assets/7fe4fefa-9c14-4ef3-86b5-a01535de700b" />
<img width="1865" height="994" alt="Screenshot 2026-02-11 at 10-35-56 Create Flow Run for Deployment DPR Processing Vincent • Prefect Server" src="https://github.com/user-attachments/assets/3e6cb6e3-8227-4858-8deb-d051c4618b60" />
<img width="1865" height="994" alt="Screenshot 2026-02-11 at 10-36-05 Create Flow Run for Deployment DPR Processing Vincent • Prefect Server" src="https://github.com/user-attachments/assets/d2fa244f-9465-4f1d-969a-f2c9391c4d05" />
