### PR TITLE
RSPY-943 - Retrial mechanism for dpr_client get_job_info function

### DIFF
--- a/rs_client/ogcapi/ogcapi_client.py
+++ b/rs_client/ogcapi/ogcapi_client.py
@@ -32,6 +32,8 @@ from requests.models import PreparedRequest
 from rs_client.rs_client import TIMEOUT, RsClient
 from rs_common.utils import get_href_service
 
+MAX_RETRIES_NUMBER_FOR_GETTING_JOB_STATUS = 20
+
 
 class OgcValidationException(Exception):
     """
@@ -279,9 +281,20 @@ class OgcApiClient(RsClient):
             previous_status: dict[str, str] = {}
             # We use previous_status to remove log when the status remains unchanged.
             # This way we reduce the number of useless information
-
+            retries_number = MAX_RETRIES_NUMBER_FOR_GETTING_JOB_STATUS
             while True:
-                job_status = self.get_job_info(job_identifier)
+                try:
+                    job_status = self.get_job_info(job_identifier)
+                except TimeoutError:
+                    retries_number -= 1
+                    if retries_number <= 0:
+                        raise
+                    time.sleep(2)
+                    logger.warning(
+                        f"Timeout while waiting for {job_name} job {job_identifier!r} status. "
+                        f"Retries left: {retries_number}",
+                    )
+                    continue
                 to_be_logged = previous_status != job_status
                 previous_status = job_status
 

--- a/tests/test_ogcapi.py
+++ b/tests/test_ogcapi.py
@@ -24,7 +24,10 @@ import responses
 from starlette import status
 
 from rs_client.ogcapi.dpr_client import ClusterInfo, DprClient
-from rs_client.ogcapi.ogcapi_client import OgcValidationException
+from rs_client.ogcapi.ogcapi_client import (
+    MAX_RETRIES_NUMBER_FOR_GETTING_JOB_STATUS,
+    OgcValidationException,
+)
 from rs_client.rs_client import RsClient
 from rs_common.logging import Logging
 from tests.conftest import MOCKED_RSPY_WEBSITE
@@ -634,6 +637,80 @@ class TestOgcApi:
         with pytest.raises(Exception) as exc_info:
             client.wait_for_job({"jobID": "jobID"})
         assert "FAILED" in str(exc_info.getrepr())
+
+    def test_wait_for_job_timeout_retry(self, client, mocker):
+        """Test the wait_for_job function with retrials on TimeoutError"""
+
+        # Mock time.sleep to make the test faster
+        mocker.patch("time.sleep", return_value=None)
+
+        job_id = "job_id_retry"
+        job_status_initial = {"jobID": job_id, "status": "accepted"}
+
+        # Define a side effect that raises TimeoutError once, then returns success
+        responses_list = [
+            TimeoutError("Mocked timeout"),
+            {"jobID": job_id, "status": "successful", "message": '{"result": "ok"}'},
+        ]
+
+        # Use side_effect to return items from the list one by one
+        mock_get_job_info = mocker.patch.object(
+            client,
+            "get_job_info",
+            side_effect=responses_list,
+        )
+
+        # Test nominal case with one retry
+        # We need to mock logger to capture warning
+        mock_logger = mocker.Mock()
+
+        result = client.wait_for_job(
+            job_status_initial,
+            logger=mock_logger,
+            job_name="test_retry_job",
+            poll_interval=0.1,
+        )
+
+        if isinstance(client, DprClient):
+            assert result == {"result": "ok"}
+        else:
+            assert result["status"] == "successful"
+
+        assert mock_get_job_info.call_count == 2
+        # For DprClient, there's an additional warning about how to cancel the job
+        if isinstance(client, DprClient):
+            assert mock_logger.warning.call_count == 2
+            # The retry warning should be the second one
+            assert (
+                "Timeout while waiting for test_retry_job job 'job_id_retry' status. Retries left: 19"
+                in mock_logger.warning.call_args_list[1][0][0]
+            )
+        else:
+            mock_logger.warning.assert_called_once()
+            assert (
+                "Timeout while waiting for test_retry_job job 'job_id_retry' status. Retries left: 19"
+                in mock_logger.warning.call_args[0][0]
+            )
+
+        # Test exhaustive retries
+        mock_get_job_info.reset_mock()
+        mock_get_job_info.side_effect = TimeoutError("Persistent Timeout")
+
+        # We want to check it raises TimeoutError after MAX_RETRIES_NUMBER_FOR_GETTING_JOB_STATUS
+        mock_logger.reset_mock()
+        with pytest.raises(TimeoutError):
+            client.wait_for_job(
+                job_status_initial,
+                logger=mock_logger,
+                job_name="test_retry_job_exhausted",
+                poll_interval=0.1,
+            )
+
+        assert mock_get_job_info.call_count == MAX_RETRIES_NUMBER_FOR_GETTING_JOB_STATUS
+        expected_warning_count = MAX_RETRIES_NUMBER_FOR_GETTING_JOB_STATUS - 1
+        if isinstance(client, DprClient):
+            expected_warning_count += 1
+        assert mock_logger.warning.call_count == expected_warning_count
 
     def test_run_conv_safe_zarr(self, client, mocker):
         """Test the run_conv_safe_zarr function"""


### PR DESCRIPTION
Implementation of a retrial mechanism for the get_job_info request from dpr_client to dpr_service. Even though the timeout of this request is 30 seconds (by default), there may be times when this request may backfire Timeout exception. A retrial mechanism with 20 nb of retries (by default) was needed