### PR TITLE
Add a new script to install dependencies with uv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2023-2026 Airbus, CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See https://mil.ad/blog/2024/uv-poetry-install.html
+
+uv tool install pip
+uv tool install poetry
+# install poetry dependencies with uv (faster)
+uv pip install --no-deps -r <(POETRY_WARNINGS_EXPORT=false poetry export --without-hashes -f requirements.txt)
+# install the package itself
+uv pip install -e .
+# install opentelemetry instrumentation libraries
+uv run --active opentelemetry-bootstrap -a install


### PR DESCRIPTION
This allows to install module with its opentelemetry-enabled dependencies in as fast way.

Useful for making https://github.com/RS-PYTHON/rs-workflow-deployment agnostic of the project dependencies.