### PR TITLE
RSPY-1029 - Allow to stage only certain assets by name

### DIFF
--- a/config/staging_templates/yaml/execute.yaml
+++ b/config/staging_templates/yaml/execute.yaml
@@ -16,7 +16,7 @@ type: object
 properties:
   inputs:
     additionalProperties:
-      oneOf:
+      anyOf:
         - $ref: "inlineOrRefData.yaml"
         - type: array
           items:

--- a/rs_client/ogcapi/ogcapi_client.py
+++ b/rs_client/ogcapi/ogcapi_client.py
@@ -80,7 +80,7 @@ class OgcApiClient(RsClient):
 
         if result.errors:
             raise OgcValidationException(
-                f"Error validating the request of the endpoint "
+                f"Error validating the request body {request.body!r} of the endpoint "
                 f"{openapi_request.path}: {', '.join(str(x) for x in result.errors)}",
             )
         if not result.body:
@@ -226,7 +226,6 @@ class OgcApiClient(RsClient):
         job_status: dict,
         logger=None,
         job_name: str = "",
-        # timeout: int | float = math.inf,
         poll_interval: int = 2,
     ) -> dict:
         """
@@ -236,8 +235,6 @@ class OgcApiClient(RsClient):
             job_status: Returned by `_run_process`
             logger: To show advancement in logger
             job_name: Job name to show in the logger
-            timeout: Job completion timeout in seconds.
-                        NOTE: This argument has been disabled, see the comment bellow !
             poll_interval: When to check again for job completion in seconds
 
         Returns:

--- a/rs_client/ogcapi/staging_client.py
+++ b/rs_client/ogcapi/staging_client.py
@@ -62,6 +62,7 @@ class StagingClient(OgcApiClient):
         self,
         stac_input: dict[Any, Any] | str,
         out_coll_name: str,
+        asset_names: set[str] | None = None,
     ) -> dict[str, dict]:
         """Method to start the staging process from rs-client - Call the endpoint /processes/staging/execution
 
@@ -74,7 +75,9 @@ class StagingClient(OgcApiClient):
                 - A single link that returns a STAC itemCollection: this link should be an url to search a
                   itemCollection, for example:
                   http://localhost:8002/cadip/search?ids=S1A_20231120061537234567&collections=cadip_sentinel1
-        out_coll_name (str): name of the output collection
+            out_coll_name (str): name of the output collection
+            asset_names (set[str]): An optional set to keep only selected asset names.
+                                    If not provided, all assets are staged.
         Return:
             dict(hostname, job_id (int, str)): Returns the status codes of the staging requests (one per URL hostname) +
             the identifiers
@@ -83,11 +86,10 @@ class StagingClient(OgcApiClient):
 
         # ----- Case 1: we only load a link (that refers to a STAC itemCollection) in the staging request body
         if isinstance(stac_input, str):
-
             # Check that it's an url
             parsed = urlparse(stac_input)
             if parsed.scheme and parsed.netloc and parsed.hostname:
-                staging_body = {"inputs": {"collection": out_coll_name, "items": {"href": stac_input}}}
+                staging_body = self.staging_body(out_coll_name, {"href": stac_input}, asset_names)
                 return {parsed.hostname: super()._run_process(RESOURCE, staging_body)}
 
         # ----- Case 2: we directly load a STAC ItemCollection in the staging request body
@@ -139,21 +141,31 @@ class StagingClient(OgcApiClient):
         hostname_triggers: dict[str, dict] = {}
         for hostname, items in hostname_items.items():
             stac_item_collection = ItemCollection(type="FeatureCollection", features=items)
-            staging_body = {
-                "inputs": {
-                    "collection": out_coll_name,
-                    "items": {"value": stac_item_collection.model_dump(mode="json")},
-                },
-            }
+            staging_body = self.staging_body(
+                out_coll_name,
+                {"value": stac_item_collection.model_dump(mode="json")},
+                asset_names,
+            )
             hostname_triggers[hostname] = super()._run_process(RESOURCE, staging_body)
 
         return hostname_triggers
+
+    def staging_body(
+        self,
+        collection: str,
+        items: dict[str, Any],
+        asset_names: set[str] | None = None,
+    ) -> dict[str, Any]:
+        """Build the staging request body with provided arguments"""
+        inputs = {"collection": collection, "items": items}
+        if asset_names:
+            inputs["asset_names"] = list(asset_names)
+        return {"inputs": inputs}
 
     def wait_for_jobs(
         self,
         all_job_status: dict[str, dict],
         logger=None,
-        # timeout: int | float = math.inf,
         poll_interval: int = 2,
     ) -> dict[str, dict]:
         """
@@ -162,8 +174,6 @@ class StagingClient(OgcApiClient):
         Args:
             job_status: Returned by `run_staging`
             logger: To show advancement in logger
-            timeout: Job completion timeout in seconds
-                    NOTE: This argument has been disabled, see the comment in super().wait_for_job() function
             poll_interval: When to check again for job completion in seconds
 
         Returns:
@@ -179,7 +189,6 @@ class StagingClient(OgcApiClient):
                 job_status,
                 logger,
                 f"Staging from {hostname!r}",
-                # timeout,
                 poll_interval,
             )
         return job_results

--- a/rs_workflows/staging_flow.py
+++ b/rs_workflows/staging_flow.py
@@ -26,7 +26,7 @@ async def staging(
     env: FlowEnvArgs,
     stac_input: str | ItemCollection | dict,  # warning: dict as last choice for prefect ui
     catalog_collection_identifier: str,
-    # timeout: int = 1200,
+    asset_names: set[str] | None = None,
     poll_interval: int = 2,
 ) -> dict[str, dict]:
     """
@@ -40,10 +40,9 @@ async def staging(
             - A json string corresponding to a Feature or a FeatureCollection<br>
             - A string corresponding to a path to a json file containing a Feature or a FeatureCollection<br>
             - A single link that returns a STAC ItemCollection: this link should be an url to search an ItemCollection
-        catalog_collection_identifier: Catalog collection identifier where items are staged
-        timeout: Job completion timeout in seconds
-            NOTE: This argument has been disabled, see the comment in staging_client.wait_for_jobs function
-        poll_interval: When to check again for job completion in seconds
+        catalog_collection_identifier (str): Catalog collection identifier where items are staged
+        asset_names (set[str]): Optional set to keep only selected asset names. If not provided, all assets are staged.
+        poll_interval (int): When to check again for job completion in seconds
 
     Returns:
         dict[str, dict]: Job status after completion
@@ -61,11 +60,10 @@ async def staging(
             stac_input = stac_input.to_dict()
 
         # Trigger the staging and wait for jobs to finish
-        job_status = staging_client.run_staging(stac_input, catalog_collection_identifier)
+        job_status = staging_client.run_staging(stac_input, catalog_collection_identifier, asset_names)
         job_status = staging_client.wait_for_jobs(
             job_status,
             logger,
-            # timeout,
             poll_interval,
         )
 


### PR DESCRIPTION
This is needed to stage only https assets from CDSE, as their pregenerated S3 URLs do not work

See https://forum.dataspace.copernicus.eu/t/aws-presigned-urls-do-not-work-on-the-s3-resources/3962

- https://github.com/RS-PYTHON/rs-server/pull/1868