### PR TITLE
RSPY-1047 - Implement AUX file retrieval multiplicity

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -27,6 +27,7 @@ header:
     - '**/*.raw'
     - '**/Dockerfile*'
     - '**/.gitignore'
+    - '**/.prefectignore'
     - '.gitmodules'
     - '.safety-project.ini'
     - '.trivyignore'

--- a/.prefectignore
+++ b/.prefectignore
@@ -1,0 +1,41 @@
+# prefect artifacts
+.prefectignore
+
+# python artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+*.egg
+
+# Type checking artifacts
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.pyre/
+
+# IPython
+profile_default/
+ipython_config.py
+*.ipynb_checkpoints/*
+
+# Environments
+.python-version
+.env
+.venv
+env/
+venv/
+
+# MacOS
+.DS_Store
+
+# Dask
+dask-worker-space/
+
+# Editors
+.idea/
+.vscode/
+
+# VCS
+.git/
+.hg/

--- a/rs_client/stac/catalog_client.py
+++ b/rs_client/stac/catalog_client.py
@@ -226,7 +226,7 @@ class CatalogClient(StacBase):  # type: ignore # pylint: disable=too-many-ancest
     ) -> ItemCollection | None:
         """Search items inside a specific collection."""
 
-        if "collections" in kwargs:
+        if "collections" in kwargs and kwargs["collections"]:
             kwargs["collections"] = [
                 self.full_collection_id(kwargs.get("owner_id"), collection, "_") for collection in kwargs["collections"]
             ]  # type: ignore

--- a/rs_workflows/auxip_flow.py
+++ b/rs_workflows/auxip_flow.py
@@ -169,7 +169,7 @@ async def search(
     flow_env = FlowEnv(env)
     with flow_env.start_span(__name__, "auxip-search"):
 
-        logger.info("Start Auxip search")
+        logger.info(f"Start Auxip search: {auxip_cql2}")
         auxip_client: AuxipClient = flow_env.rs_client.get_auxip_client()
         found = auxip_client.search(
             method="POST",

--- a/rs_workflows/catalog_flow.py
+++ b/rs_workflows/catalog_flow.py
@@ -37,6 +37,7 @@ async def catalog_search(
     env: FlowEnvArgs,
     catalog_cql2: dict,
     error_if_empty: bool = False,
+    collections: list[str] | None = None,
 ) -> ItemCollection | None:
     """
     Search Catalog items.
@@ -45,6 +46,7 @@ async def catalog_search(
         env: Prefect flow environment (at least the owner_id is required)
         catalog_cql2: CQL2 filter.
         error_if_empty: Raise a ValueError if the results are empty.
+        collections: list of collection names to search in
     """
     logger = get_run_logger()
 
@@ -52,13 +54,14 @@ async def catalog_search(
     flow_env = FlowEnv(env)
     with flow_env.start_span(__name__, "catalog-search"):
 
-        logger.info("Start Catalog search")
+        logger.info(f"Start Catalog search: {catalog_cql2}")
         catalog_client: CatalogClient = flow_env.rs_client.get_catalog_client()
         found = catalog_client.search(
             method="POST",
             stac_filter=catalog_cql2.get("filter"),
             max_items=catalog_cql2.get("limit"),
             sortby=catalog_cql2.get("sortby"),
+            collections=collections,
         )
         if (not found) and error_if_empty:
             raise ValueError(

--- a/rs_workflows/on_demand/common/l0_last_steps.py
+++ b/rs_workflows/on_demand/common/l0_last_steps.py
@@ -46,7 +46,7 @@ async def process_l0_last_steps(
 
     # Resolve parameters
     flow_params = flow_params or Level0FlowParams()
-    p = await flow_params.resolve(mission=mission)
+    p = await flow_params.resolve(mission)
 
     flow_env = FlowEnv(FlowEnvArgs(owner_id=p.owner_identifier))
 

--- a/rs_workflows/on_demand_processing.py
+++ b/rs_workflows/on_demand_processing.py
@@ -19,14 +19,19 @@
 import datetime
 import json
 import os
+import re
 import tempfile as std_tempfile
+from copy import deepcopy
+from typing import Any
 
 import anyio
 import yaml
 from prefect import flow, get_run_logger, task
 from prefect.artifacts import acreate_markdown_artifact
+from pystac import Item, ItemCollection
 
 from rs_client.ogcapi.dpr_client import ClusterInfo
+from rs_client.rs_client import RsClient
 from rs_client.stac.catalog_client import CatalogClient
 from rs_common import prefect_utils
 from rs_workflows import auxip_flow, catalog_flow
@@ -35,10 +40,14 @@ from rs_workflows.flow_utils import (
     ARCHIVE_SUFFIXES,
     DprProcessIn,
     FlowEnv,
+    FlowInputProduct,
     RetryConfig,
 )
 from rs_workflows.payload_builder import build_cql2_json, build_unit_list
-from rs_workflows.payload_generator import generate_payload
+from rs_workflows.payload_generator import generate_payload, resolve_stac_input_path
+from rs_workflows.utils.utils import search_by_name
+
+SPECIFIC_INPUT_PATTERN = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_]*)\}")
 
 
 def build_dask_dashboard_url_message(cluster_instance: str | None) -> str:
@@ -52,7 +61,7 @@ def build_dask_dashboard_url_message(cluster_instance: str | None) -> str:
     return f"Dask cluster dashboard URL: {dashboard_url}"
 
 
-def _select_aux_collection(dpr_input, product_type: str) -> str:
+def _select_aux_collection(dpr_input: DprProcessIn, product_type: str) -> str:
     """
     Resolve the catalog collection identifier for a requested AUX product type.
 
@@ -80,7 +89,13 @@ def _select_aux_collection(dpr_input, product_type: str) -> str:
     )
 
 
-async def _build_auxip_request(alternative, input_adfs, dpr_input, task_table) -> tuple[dict, str, int]:
+async def _build_auxip_request(
+    alternative,
+    input_adfs,
+    dpr_input: DprProcessIn,
+    task_table: dict[str, Any],
+    specific_input_product: tuple[str | None, Item | None] = (None, None),
+) -> tuple[dict, str, int]:
     """
     Build the AUXIP request data for a single ADFS alternative.
 
@@ -95,8 +110,20 @@ async def _build_auxip_request(alternative, input_adfs, dpr_input, task_table) -
     """
     timeout = alternative["timeout_seconds"]  # pylint: disable = unused-variable
     name = alternative["query"]["name"]
-    parameters = alternative["query"]["parameters"]
-    auxip_cql2 = build_cql2_json(task_table, name, parameters)["stac"]
+    specific_input_name, stac_item = specific_input_product
+    parameters = {
+        k: (
+            stac_item.properties.get(m.group(2), v)
+            if stac_item
+            and isinstance(v, str)
+            and (m := SPECIFIC_INPUT_PATTERN.match(v))
+            and m.group(1) == specific_input_name
+            else v
+        )
+        for k, v in deepcopy(alternative["query"]["parameters"]).items()
+    }
+    query = next(q for q in task_table["queries"] if q["name"] == name)
+    auxip_cql2 = build_cql2_json(query, parameters)
 
     md = "# Auxip CQL2 filter \n\n```json\n" + json.dumps(auxip_cql2, indent=2) + "\n```"
     await acreate_markdown_artifact(key="auxip-cql2", markdown=md, description="Auxip CQL2 filter")
@@ -104,7 +131,7 @@ async def _build_auxip_request(alternative, input_adfs, dpr_input, task_table) -
     product_type = parameters.get("product_type", "*")
     collection = _select_aux_collection(dpr_input, product_type)
     get_run_logger().info(
-        f"Prepared AUXIP request for input {input_adfs['name']} using collection {collection}",
+        f"Prepared AUXIP request for input {input_adfs['name']} using collection {collection}: {auxip_cql2}",
     )
     return auxip_cql2, collection, timeout if timeout else -1
 
@@ -175,11 +202,12 @@ async def _normalize_archived_auxip_items(item_collection, dpr_input):
 
 async def _stage_input_adfs_alternative(
     alternative,
-    input_adfs,
-    dpr_input,
-    task_table,
-    staging_retries,
-    staging_retry_delay,
+    input_adfs: dict[str, Any],
+    dpr_input: DprProcessIn,
+    task_table: dict[str, Any],
+    specific_input_product: tuple[str | None, Item | None] = (None, None),
+    staging_retries: int = 3,
+    staging_retry_delay: int = 60,
 ):
     """
     Stage one ADFS alternative and normalize archived outputs when needed.
@@ -195,40 +223,46 @@ async def _stage_input_adfs_alternative(
     the next alternative in order.
     """
     logger = get_run_logger()
-    auxip_cql2, collection, timeout = await _build_auxip_request(alternative, input_adfs, dpr_input, task_table)
-    logger.info(f"Selected collection {collection}")
+    auxip_cql2, collection, timeout = await _build_auxip_request(
+        alternative,
+        input_adfs,
+        dpr_input,
+        task_table,
+        specific_input_product,
+    )
+    logger.info(f"Selected ADFS collection {collection}")
 
-    auxip_items = (
+    auxip_status: bool
+    auxip_items: ItemCollection | None
+    auxip_status, auxip_items = (
         auxip_flow.auxip_staging_task.with_options(
             retries=staging_retries,
             retry_delay_seconds=staging_retry_delay,
         )
-        .submit(
-            dpr_input.env,
-            auxip_cql2,
-            collection,
-            timeout,
-        )
+        .submit(dpr_input.env, auxip_cql2, collection, timeout)
         .result()
     )
-    logger.info(f"Staged ADFS: {auxip_items}")
 
-    if not auxip_items[1]:  # type: ignore
+    if not auxip_items:
         return None
 
-    item_collection = await _normalize_archived_auxip_items(auxip_items[1], dpr_input)  # type: ignore
+    for auxip_item in auxip_items:
+        logger.info(f"Staged ADFS: {auxip_item}")
+
+    item_collection = await _normalize_archived_auxip_items(auxip_items, dpr_input)
 
     logger.info(f"Finished processing input ADFS, ItemCollection size: {len(item_collection.items)}")
     logger.debug(f"Finished processing input ADFS, ItemCollection: {item_collection.to_dict()}")
 
-    return input_adfs["name"], (auxip_items[0], item_collection)  # type: ignore[index]
+    return input_adfs["name"], (auxip_status, item_collection)
 
 
 @task(name="Process input ADFS")
 async def process_input_adfs(
-    input_adfs,
-    dpr_input,
-    task_table,
+    input_adfs: dict[str, Any],
+    dpr_input: DprProcessIn,
+    task_table: dict[str, Any],
+    specific_input_product: tuple[str | None, Item | None] = (None, None),
     staging_retries: int = 3,
     staging_retry_delay: int = 60,
 ):
@@ -268,6 +302,7 @@ async def process_input_adfs(
                 input_adfs,
                 dpr_input,
                 task_table,
+                specific_input_product,
                 staging_retries,
                 staging_retry_delay,
             )
@@ -282,6 +317,58 @@ async def process_input_adfs(
         ) from kerr
 
 
+def _resolve_specific_input_product_stac_items(
+    input_adfs: dict[str, Any],
+    task_table: dict[str, Any],
+    unit: dict[str, Any],
+    provided_input_products: list[FlowInputProduct],
+    rs_client: RsClient,
+) -> tuple[str | None, list[Item | None]]:
+    input_adfs_io = search_by_name(task_table["io"], input_adfs["name"])
+    if input_adfs_io.get("multiplicity", None) == "one_per_input":
+        logger = get_run_logger()
+        input_product_names: set[str] = {product["name"] for product in unit["input_products"]}
+        referenced_input_product_names = {
+            match.group(1)
+            for alt in input_adfs_io.get("alternatives", [])
+            for value in alt.get("query", {}).get("parameters", {}).values()
+            if isinstance(value, str)
+            for match in [re.fullmatch(r"\{([^\.}]+)\.[^}]+\}", value)]
+            if match and match.group(1) in input_product_names
+        }
+        if len(referenced_input_product_names) != 1:
+            raise ValueError(
+                f"ADFS multiplicy 'one_per_input' shall refer to a single input product, "
+                f"found '{referenced_input_product_names}'",
+            )
+        referenced_input_product_name = next(iter(referenced_input_product_names))
+        logger.info(f"ADFS multiplicity 'one_per_input' refers to input '{referenced_input_product_name}'")
+        input_product_io: dict[str, Any] = search_by_name(task_table["io"], referenced_input_product_name)
+        input_product_regex: str = input_product_io["store_params"]["regex"]
+        if not input_product_regex:
+            raise ValueError(
+                f"Input product '{referenced_input_product_name}' shall define a regex to perform discrimination",
+            )
+        result = []
+        catalog_client: CatalogClient = rs_client.get_catalog_client()
+        for input_product in provided_input_products:
+            stac_item, first_asset_path = resolve_stac_input_path(
+                catalog_client,
+                input_product.collection_name,
+                input_product.item_id,
+            )
+            # Check that first asset path matches input product regex
+            logger.info(f"Checking asset path '{first_asset_path}' against regex '{input_product_regex}'")
+            if not first_asset_path or not re.fullmatch(input_product_regex, first_asset_path):
+                logger.debug(f"Ignore path {first_asset_path} as it doesn't match regex '{input_product_regex}'")
+                continue
+            result.append(stac_item)
+        if not result:
+            logger.error(f"Found no STAC item with assets matching the regex '{input_product_regex}'")
+        return referenced_input_product_name, result
+    return None, [None]
+
+
 @flow
 async def dpr_processing(
     dpr_input: DprProcessIn,
@@ -291,16 +378,8 @@ async def dpr_processing(
     Prefect flow for dpr-process.
 
     Args:
-        env: Prefect flow environment
-        processor: DPR processor name
-        cluster_label (str): Dask cluster label e.g. "dask-l0"
-        cadip_collection_identifier: CADIP collection identifier that contains the mission and station
-            (e.g. s1_ins for Sentinel-1 sessions from the Inuvik station)
-        session_identifier: Session identifier
-        catalog_collection_identifier: Catalog collection identifier where CADIP sessions and AUX data are staged
-        s3_payload_template: S3 bucket location of the DPR payload file template.
-        s3_output_data: S3 bucket location of the output processed products. They will then be copied to the
-        catalog bucket.
+        dpr_input: Input parameters for executing this flow
+        retry_config: Staging retry config
     """
     logger = get_run_logger()
     logger.info(f"Starting the DPR processing flow with processor: {dpr_input.processor_name}")
@@ -318,7 +397,10 @@ async def dpr_processing(
         )
 
         # read tasktable and construct list of processing units
-        task_table = flow_env.rs_client.get_dpr_client().get_process(dpr_input.processor_name, cluster_info)
+        task_table: dict[str, Any] = flow_env.rs_client.get_dpr_client().get_process(
+            dpr_input.processor_name,
+            cluster_info,
+        )
 
         # Persist the full task table as a Prefect artifact for later investigation.
         md = "# Task table\n\n```json\n" + json.dumps(task_table, indent=2) + "\n```"
@@ -348,31 +430,45 @@ async def dpr_processing(
         for unit in unit_list:
             # For each input_adfs element computed on STEP 1
             for input_adfs in unit["input_adfs"]:
-                tasks.append(
-                    process_input_adfs.submit(
-                        input_adfs,
-                        dpr_input,
-                        task_table,
-                        retry_config.staging_retries,
-                        retry_config.staging_retry_delay,
-                    ),
+                # For each specific input in case of multiplicity=one_per_input
+                specific_input_name, product_stac_items = _resolve_specific_input_product_stac_items(
+                    input_adfs,
+                    task_table,
+                    unit,
+                    dpr_input.input_products,
+                    flow_env.rs_client,
                 )
+                for specific_input_product_stac_item in product_stac_items:
+                    if specific_input_product_stac_item:
+                        logger.info(
+                            f"Submitting '{input_adfs["name"]}' ADFS task for input {specific_input_product_stac_item}",
+                        )
+                    tasks.append(
+                        process_input_adfs.submit(
+                            input_adfs,
+                            dpr_input,
+                            task_table,
+                            (specific_input_name, specific_input_product_stac_item),
+                            retry_config.staging_retries,
+                            retry_config.staging_retry_delay,
+                        ),
+                    )
 
         try:
             auxip_items = [t.result() for t in tasks]
         except (RuntimeError, KeyError) as err:
             raise err
 
-        adfs = []
+        adfs: set[tuple[str, str]] = set()
         for name, (status, item_collection) in auxip_items:  # type: ignore
             for item in item_collection.items:  # type: ignore
                 if status:  # type: ignore
                     asset = next(iter(item.assets.values()))
-                    adfs.append((name, asset.href))  # type: ignore
+                    adfs.add((name, asset.href))  # type: ignore
                 else:
                     raise ValueError(f"The adf input files {next(iter(item.assets.values()))} was not correctly staged")
         # generate the dpr payload file
-        task_future = generate_payload.submit(flow_env, unit_list, adfs, dpr_input)
+        task_future = generate_payload.submit(flow_env, unit_list, list(adfs), dpr_input)
         # get the payload generation result
         generated_payload_res = task_future.result()
         # create the generated payload as a dictionary, as it will be used for

--- a/rs_workflows/payload_builder.py
+++ b/rs_workflows/payload_builder.py
@@ -21,7 +21,8 @@ from typing import Any
 
 from rs_common.utils import strftime_millis
 
-EXTERNAL_VAR_PATTERN = re.compile(r"^\{external_variable\.([a-zA-Z_][a-zA-Z0-9_]*)\}$")
+EXTERNAL_VAR_PATTERN = re.compile(r"\{external_variable\.([a-zA-Z_][a-zA-Z0-9_]*)\}")
+VARIABLE_PATTERN = re.compile(r"^{(.*)}$")  # matches exactly "{var}" (whole string)
 
 
 class TaskTableError(ValueError):
@@ -34,11 +35,15 @@ def _replace_external_variables(obj, external_variables: dict[str, Any] | None):
     if isinstance(obj, list):
         return [_replace_external_variables(v, external_variables) for v in obj]
     if isinstance(obj, str) and external_variables:
-        match = EXTERNAL_VAR_PATTERN.match(obj)
-        if match:
+
+        def replacer(match: re.Match):
             variable_name = match.group(1)
+            if variable_name not in external_variables:
+                raise TaskTableError(f"Unknown external variable: {variable_name}")
             value = external_variables[variable_name]
-            return strftime_millis(value) if "datetime" in variable_name else value
+            return strftime_millis(value) if "datetime" in variable_name else str(value)
+
+        return EXTERNAL_VAR_PATTERN.sub(replacer, obj)
     return obj
 
 
@@ -289,29 +294,22 @@ def build_unit_list(
     return {"units": out_units}
 
 
-def build_cql2_json(task_table, query_name, values):
+def build_cql2_json(query: dict[str, Any], values: dict[str, Any]):
     """
     Recursively replaces placeholders of the form {var} in a dictionary or list
     using the mapping from 'values'.
     """
-    template = {}
-    for cql_filter in task_table["queries"]:
-        if cql_filter["name"] == query_name:
-            # Work on a deep copy so we don't mutate the original
-            template = deepcopy(cql_filter)
-    pattern = re.compile(r"^{(.*)}$")  # matches exactly "{var}" (whole string)
 
     def _replace(item):
         if isinstance(item, str):
-            match = pattern.match(item)
-            if match:
-                key = match.group(1)
-                return values.get(key, item)  # replace if found, else keep
-            return item
+            # replace if found, else keep
+            match = VARIABLE_PATTERN.match(item)
+            return values.get(match.group(1), item) if match else item
         if isinstance(item, list):
             return [_replace(x) for x in item]
         if isinstance(item, dict):
             return {k: _replace(v) for k, v in item.items()}
         return item
 
-    return _replace(template)
+    # Work on a deep copy so we don't mutate the original
+    return _replace(deepcopy(query))["stac"]

--- a/rs_workflows/payload_generator.py
+++ b/rs_workflows/payload_generator.py
@@ -16,6 +16,8 @@
 
 import fnmatch
 import os
+from collections import defaultdict
+from copy import deepcopy
 from pathlib import Path
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
@@ -26,21 +28,24 @@ from prefect.blocks.system import Secret
 from pystac import Item
 
 from rs_client.ogcapi.dpr_client import DprProcessor
+from rs_client.stac.catalog_client import CatalogClient
 from rs_common import prefect_utils
-from rs_workflows.flow_utils import (  # FlowEnvArgs,
+from rs_workflows.flow_utils import (
     DprProcessIn,
     FlowEnv,
 )
-from rs_workflows.payload_template import (  # DaskContext,; StorageOptions,; StoreParams,
+from rs_workflows.payload_template import (
     AdfConfig,
     GeneralConfiguration,
     InputProduct,
     IOConfig,
     OutputProduct,
     PayloadSchema,
+    StoreParams,
     WorkflowStep,
 )
 from rs_workflows.storage_configuration import StorageConfig
+from rs_workflows.utils.utils import get_common_and_relative_paths, search_by_name
 
 FILEPATH_ENV_VAR = "BUCKET_CONFIG_FILE_PATH"
 DEFAULT_FILEPATH = "/app/conf/expiration_bucket.csv"
@@ -112,14 +117,20 @@ def build_workflow_step(unit):
 
 def get_first_asset_dir(item: Item) -> str | None:
     """
-    Returns the local or remote path component from the href of the first asset in a pystac Item.
+    Returns the directory path (local or remote) derived from the href of the first asset in a pystac Item.
+
+    Special case:
+        If the first asset is a Zarr store (media_type "application/vnd+zarr"),
+        the full href is returned unchanged, since it already represents a directory-like dataset.
 
     Args:
         item (pystac.Item): The STAC item containing assets.
 
     Returns:
-        str | None: The path component of the first asset's href, or None if no assets exist.
+        str | None: The resolved directory path or URL of the first asset, or None if no assets exist.
         Examples:
+            s3://dev-bucket/path/to/folder.zarr
+              ->  s3://dev-bucket/path/to/folder.zarr (Zarr store, returned as-is)
             s3://dev-bucket/path/to/cadu.raw  ->  s3://dev-bucket/path/to
             /local/path/to/file.raw       ->  /local/path/to
             https://example.com/data/file.tif -> https://example.com/data
@@ -129,6 +140,9 @@ def get_first_asset_dir(item: Item) -> str | None:
 
     first_asset = next(iter(item.assets.values()))
     href = first_asset.href
+
+    if first_asset.media_type == "application/vnd+zarr":
+        return href
 
     parsed = urlparse(href)
 
@@ -277,7 +291,7 @@ def find_s3_output_bucket(
     )
 
 
-def resolve_stac_input_path(catalog_client, collection: str, stac_item_id: str) -> str:
+def resolve_stac_input_path(catalog_client: CatalogClient, collection: str, stac_item_id: str) -> tuple[Item, str]:
     """
     Retrieves the S3 path of the first asset from a STAC item within a collection.
 
@@ -287,7 +301,7 @@ def resolve_stac_input_path(catalog_client, collection: str, stac_item_id: str) 
         stac_item_id (str): The STAC item identifier to resolve.
 
     Returns:
-        str: The path to the first asset of the specified STAC item.
+        tuple[Item, str]: The specified STAC item and the path to its first asset.
 
     Raises:
         RuntimeError: If the STAC item is missing or contains no assets.
@@ -300,14 +314,14 @@ def resolve_stac_input_path(catalog_client, collection: str, stac_item_id: str) 
     if not stac_item_path:
         raise RuntimeError(f"STAC item '{stac_item_id}' in collection '{collection}' has no assets.")
 
-    return stac_item_path
+    return stac_item, stac_item_path
 
 
 def build_input_products(
     unit,
     dpr_process_in: DprProcessIn,
     storage_configuration: StorageConfig,
-    catalog_client,
+    catalog_client: CatalogClient,
 ) -> list[InputProduct]:
     """
     Builds the list of input product configurations for a workflow step.
@@ -330,25 +344,18 @@ def build_input_products(
         RuntimeError: If an expected input product or STAC item cannot be found.
     """
     inputs = []
+
+    # Group input products by name (needed for inputs of type regex)
+    grouped_products = defaultdict(list)
     for input_product in dpr_process_in.input_products:
-        product_name = input_product.name
+        grouped_products[input_product.name].append(input_product)
 
-        mapping = next(
-            (inp for inp in unit.get("input_products", []) if inp["name"] == product_name),
-            None,
-        )
+    # Iterate over each group of products
+    for product_name, products in grouped_products.items():
 
+        mapping = search_by_name(unit.get("input_products", []), product_name)
         if not mapping:
             raise RuntimeError(f"Couldn't find any input for task table entry '{product_name}'")
-
-        stac_item_identifier = input_product.item_id
-        collection = input_product.collection_name
-
-        stac_item_path = resolve_stac_input_path(
-            catalog_client,
-            collection,
-            stac_item_identifier,
-        )
 
         # cf story 871/Set S3 configuration in payload.yaml
         store_name = storage_configuration.get_storage_for_specific_product(product_name)
@@ -361,20 +368,60 @@ def build_input_products(
                 ) or storage_configuration.get_storage_for_pipeline_section("other")
         if not store_name:
             raise RuntimeError(f"Couldn't find any storage configuration for input product '{product_name}'")
-        inputs.append(
-            InputProduct(
-                id=mapping["name"],
-                path=stac_item_path,
-                # TODO: The value for this filed in the tasktable (from where the unit is built) should be 'filename'
-                # in case of s1 l0 processor, otherwise the s1 l0 processor is failing in starting.
-                # check in the tasktable from rs-dpr-service (config/TaskTable_S1_L0_generated_by_rs_python_v1.json)
-                # that in section io, the type field is set to 'filename' for input_products (S1ACADUS).
-                # To be fixed in future iterations !
-                type=mapping.get("type", "filename"),
-                store_type=mapping["store_type"],
-                store_params=storage_configuration.get_store_params(store_name),
-            ),
-        )
+        store_params = deepcopy(storage_configuration.get_store_params(store_name))
+
+        if len(products) == 1:
+            # Standard case where each input product has a different name (i.e. single STAC item)
+            input_product = products[0]
+            _, stac_item_path = resolve_stac_input_path(
+                catalog_client,
+                input_product.collection_name,
+                input_product.item_id,
+            )
+
+            inputs.append(
+                InputProduct(
+                    id=mapping["name"],
+                    path=stac_item_path,
+                    # TODO: The value for this field in the tasktable (from where the unit is built) should be
+                    # 'filename' in case of s1 l0 processor, otherwise the s1 l0 processor is failing in starting.
+                    # check in the tasktable from rs-dpr-service (config/TaskTable_S1_L0_generated_by_rs_python_v1.json)
+                    # that in section io, the type field is set to 'filename' for input_products (S1ACADUS).
+                    # To be fixed in future iterations !
+                    type=mapping.get("type", "filename"),
+                    store_type=mapping["store_type"],
+                    store_params=store_params,
+                ),
+            )
+        elif isinstance(store_params, StoreParams):
+            # Advanced case where several input products share the same name (i.e. several STAC items)
+            store_params.multiplicity = str(len(products))
+
+            # Retrieve all paths
+            paths = [
+                resolve_stac_input_path(
+                    catalog_client,
+                    product.collection_name,
+                    product.item_id,
+                )[1]
+                for product in products
+            ]
+            # Compute longest common prefix
+            common_folder, relative_parts = get_common_and_relative_paths(paths)
+            store_params.regex = rf"({'|'.join(relative_parts)})"
+
+            # Add a single InputProduct of type regex listing the provided inputs in the common folder
+            inputs.append(
+                InputProduct(
+                    id=mapping["name"],
+                    path=common_folder,
+                    type=mapping.get("type", "regex"),
+                    store_type=mapping["store_type"],
+                    store_params=store_params,
+                ),
+            )
+        else:
+            raise RuntimeError(f"Couldn't find any storage configuration for input product '{product_name}'")
     return inputs
 
 
@@ -504,6 +551,62 @@ def get_io(
     outputs = build_output_products(unit, dpr_process_in, storage_configuration, owner_id, bucket_configuration)
 
     return inputs, outputs
+
+
+def build_adfs(
+    storage_configuration: StorageConfig,
+    adfs: list[tuple[str, str]],
+) -> list[AdfConfig]:
+    """
+    Build a list of AdfConfig objects from input ADF definitions.
+
+    ADFs are grouped by their identifier. If an identifier is associated
+    with a single path, a standard AdfConfig is created. If multiple paths
+    share the same identifier, a single AdfConfig is created using a common
+    folder and a regex pattern to match all corresponding files.
+
+    Args:
+        storage_configuration (StorageConfig): Configuration object used to
+            retrieve default storage parameters.
+        adfs (list[tuple[str, str]]): List of (adf_id, path) tuples.
+
+    Returns:
+        list[AdfConfig]: List of constructed AdfConfig objects, one per group
+        of ADFs.
+    """
+    result = []
+
+    # Group adfs by name (needed for adfs of type regex)
+    grouped_adfs = defaultdict(list)
+    for adf in adfs:
+        grouped_adfs[adf[0]].append(adf[1])
+
+    # Iterate over each group of adfs
+    for adfs_id, adfs_paths in grouped_adfs.items():
+        adfs_name = storage_configuration.default_adfs_storage
+        store_params = deepcopy(storage_configuration.get_store_params(adfs_name))
+        if len(adfs_paths) == 1:
+            # Standard case where each adfs has a different id (i.e. single file)
+            result.append(AdfConfig(id=adfs_id, path=adfs_paths[0], store_params=store_params))
+        elif isinstance(store_params, StoreParams):
+            # Advanced case where several adfs share the same id (i.e. several files)
+            store_params.multiplicity = str(len(adfs_paths))
+            # Compute longest common prefix
+            common_folder, relative_parts = get_common_and_relative_paths(adfs_paths)
+            store_params.regex = rf"({'|'.join(relative_parts)})"
+            # Add a single AdfConfig of type regex listing the provided adfs in the common folder
+            result.append(
+                AdfConfig(
+                    id=adfs_id,
+                    path=common_folder,
+                    # type="regex", # Unsupported by CPM but it feels needed here for S1ARD
+                    store_params=store_params,
+                ),
+            )
+        else:
+            raise RuntimeError(f"Couldn't find any storage configuration for adfs '{adfs_name}'")
+
+    return result
 
 
 def load_storage_configuration(
@@ -684,8 +787,7 @@ def generate_payload(  # pylint: disable=unused-argument
             raise ValueError(f"Key {ke} not found in unit list") from ke
 
     logger.info("Building ADFs section")
-    store_params = storage_configuration.get_store_params(storage_configuration.default_adfs_storage)
-    io_config.adfs = [AdfConfig(id=adf[0], path=adf[1], store_params=store_params) for adf in adfs]
+    io_config.adfs = build_adfs(storage_configuration, adfs)
 
     # Add the logging config for l0 and s1 / s3 configurations. These configurations
     # are hardcoded in the l0 eopf dask worker image. The path where these files are stored is given

--- a/rs_workflows/utils/catalog.py
+++ b/rs_workflows/utils/catalog.py
@@ -30,7 +30,7 @@ async def get_single_catalog_item(flow_env: FlowEnv, item_id: str, collections: 
     logger = get_run_logger()
     result: Item | None = None
 
-    # Try to retrieve the item on the collection
+    # Try to retrieve the item in the collections
     item_collection: ItemCollection | None = await get_catalog_items(flow_env, [item_id], collections)
 
     count = 0

--- a/rs_workflows/utils/utils.py
+++ b/rs_workflows/utils/utils.py
@@ -1,0 +1,49 @@
+# Copyright 2023-2026 Airbus, CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""General utilities"""
+
+import re
+from os.path import commonprefix
+from typing import Any
+
+
+def search_by_name(values: list[dict[str, Any]], name: str) -> Any:
+    """Return the first item whose "name" field matches the given value."""
+    return next((obj for obj in values if obj.get("name") == name), None)
+
+
+def get_common_and_relative_paths(paths: list[str]) -> tuple[str, list[str]]:
+    """
+    Returns the common folder prefix of the given paths and their escaped
+    relative parts.
+
+    The common prefix is truncated to the last `/` so it always represents
+    a directory.
+
+    Args:
+        paths (list[str]): List of absolute paths or URIs.
+
+    Returns:
+        tuple[str, list[str]]:
+            - Common folder ending with `/`
+            - Escaped relative parts for each path
+    """
+    # Compute longest common prefix
+    common_prefix = commonprefix(paths)
+    # Ensure prefix stops on folder boundary
+    common_folder = common_prefix[: common_prefix.rfind("/") + 1]
+    # Build regex from relative names inside common folder
+    relative_parts = [re.escape(path.removeprefix(common_folder)) for path in paths]
+    return common_folder, relative_parts

--- a/tests/test_payload_generator.py
+++ b/tests/test_payload_generator.py
@@ -91,7 +91,7 @@ def test_get_io_builds_input_and_output(
     """
     mocker.patch(
         "rs_workflows.payload_generator.resolve_stac_input_path",
-        return_value="s3://mocked/cadip_session",
+        return_value=(None, "s3://mocked/cadip_session"),
     )
     # the fetch_csv_from_endpoint function also needs to be mocked; otherwise,
     # it will fail to fetch the file and the test will not pass.
@@ -141,7 +141,7 @@ def test_get_io_builds_input_and_output(
 
 def test_get_io_missing_field_raises(mock_dpr_process_in, mock_store_params, flow_env, mocker):
     """
-    Test that malformed input_products (missing 'name' or 'origin') raise KeyError.
+    Test that malformed input_products (missing 'name' or 'origin') raise RuntimeError.
     """
     # the fetch_csv_from_endpoint function also needs to be mocked; otherwise,
     # it will fail to fetch the file and the test will not pass.
@@ -157,7 +157,7 @@ def test_get_io_missing_field_raises(mock_dpr_process_in, mock_store_params, flo
     mock_storage_config = MagicMock()
     mock_storage_config.get_store_params.return_value = mock_store_params
 
-    with pytest.raises(KeyError):
+    with pytest.raises(RuntimeError):
         get_io(bad_unit, mock_dpr_process_in, flow_env, mock_storage_config, [])
 
 
@@ -514,9 +514,10 @@ def test_resolve_stac_input_path(mocker, catalog_client):
     # get_first_asset_dir returns the directory (this is what the function uses)
     mocker.patch("rs_workflows.payload_generator.get_first_asset_dir", return_value="s3://catalog-bucket/items/item123")
 
-    result = resolve_stac_input_path(catalog_client, "my-collection", "item123")
+    result_item, result_path = resolve_stac_input_path(catalog_client, "my-collection", "item123")
 
-    assert result == "s3://catalog-bucket/items/item123"
+    assert result_item == mock_item
+    assert result_path == "s3://catalog-bucket/items/item123"
 
 
 # ----------------------------------------------------------------------
@@ -530,7 +531,7 @@ def test_build_input_products_success(sample_unit, mock_store_params, mocker):
     """
     mocker.patch(
         "rs_workflows.payload_generator.resolve_stac_input_path",
-        return_value="s3://path/to/item",
+        return_value=(None, "s3://path/to/item"),
     )
 
     mock_dpr = MagicMock()
@@ -546,6 +547,51 @@ def test_build_input_products_success(sample_unit, mock_store_params, mocker):
     assert inputs[0].store_type == "S3"
     assert inputs[0].path == "s3://path/to/item"
     assert inputs[0].store_params == mock_store_params
+
+
+def test_build_input_products_success_multiple_inputs_regex(sample_unit, mock_store_params, mocker):
+    """
+    Test successful build of input products when multiple inputs share the same name (regex case).
+    """
+    # Mock STAC resolution to return different paths
+    mocker.patch(
+        "rs_workflows.payload_generator.resolve_stac_input_path",
+        side_effect=[
+            ("item1", "s3://path/to/item1"),
+            ("item2", "s3://path/to/item2"),
+        ],
+    )
+
+    # Create multiple input products with SAME name
+    mock_dpr = MagicMock()
+    mock_dpr.input_products = [
+        FlowInputProduct(name="S1CADUS", item_id="item1", collection_name="coll"),
+        FlowInputProduct(name="S1CADUS", item_id="item2", collection_name="coll"),
+    ]
+
+    # Mock storage config
+    mock_storage = MagicMock()
+    mock_storage.get_storage_for_specific_product.return_value = "S3"
+    mock_storage.get_store_params.return_value = mock_store_params
+
+    # Ensure mock_store_params behaves like StoreParams
+    assert isinstance(mock_store_params, StoreParams)
+
+    inputs = build_input_products(sample_unit, mock_dpr, mock_storage, MagicMock())
+
+    # Assertions
+    assert len(inputs) == 1  # regex => single InputProduct
+
+    input_product = inputs[0]
+    assert input_product.id == "S1CADUS"
+    assert input_product.store_type == "S3"
+    assert input_product.path == "s3://path/to/"
+    assert input_product.type == "regex"
+
+    # Checks generated regex
+    assert isinstance(input_product.store_params, StoreParams)
+    assert input_product.store_params.regex == r"(item1|item2)"
+    assert input_product.store_params.multiplicity == "2"
 
 
 def test_build_input_products_missing_mapping(sample_unit):
@@ -566,7 +612,7 @@ def test_build_input_products_missing_storage(sample_unit, mocker):
     """
     mocker.patch(
         "rs_workflows.payload_generator.resolve_stac_input_path",
-        return_value="s3://path/to/item",
+        return_value=(None, "s3://path/to/item"),
     )
 
     mock_dpr = MagicMock()
@@ -591,7 +637,7 @@ def test_build_input_products_fallback_storage_unit(sample_unit, mock_store_para
     """
     mocker.patch(
         "rs_workflows.payload_generator.resolve_stac_input_path",
-        return_value="s3://path/to/item",
+        return_value=(None, "s3://path/to/item"),
     )
 
     mock_dpr = MagicMock()
@@ -617,7 +663,7 @@ def test_build_input_products_fallback_storage_pipeline(sample_unit, mock_store_
     """
     mocker.patch(
         "rs_workflows.payload_generator.resolve_stac_input_path",
-        return_value="s3://path/to/item",
+        return_value=(None, "s3://path/to/item"),
     )
 
     mock_dpr = MagicMock()

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -306,6 +306,102 @@ async def test_normalize_archived_auxip_items_wraps_catalog_update_errors(mocker
         )
 
 
+def test_resolve_specific_input_product_stac_items_nominal(mocker):
+    """
+    Nominal case:
+    - multiplicity = one_per_input
+    - exactly one referenced input product
+    - regex matches at least one STAC asset
+    """
+
+    # --- Mock logger ---
+    mock_logger = MagicMock()
+    mocker.patch(
+        "rs_workflows.on_demand_processing.get_run_logger",
+        return_value=mock_logger,
+    )
+
+    # Mock STAC resolution to return different paths
+    mocker.patch(
+        "rs_workflows.on_demand_processing.resolve_stac_input_path",
+        side_effect=[
+            ("item1", "s3://path/to/item1"),
+            ("item2", "s3://path/to/item2"),
+        ],
+    )
+
+    # --- Mock RS client / catalog ---
+    mock_catalog = MagicMock()
+    mock_rs_client = MagicMock()
+    mock_rs_client.get_catalog_client.return_value = mock_catalog
+
+    # --- Input ADFS ---
+    input_adfs = {
+        "name": "ADFS_INPUT",
+    }
+
+    # --- Task table ---
+    task_table = {
+        "io": [
+            {
+                "name": "ADFS_INPUT",
+                "multiplicity": "one_per_input",
+                "alternatives": [
+                    {
+                        "order": 1,
+                        "timeout_seconds": 0,
+                        "query": {
+                            "name": "LatestValCover",
+                            "parameters": {
+                                "product_type": "SOMETHING",
+                                "start_datetime": "{S1CADUS.start_datetime}",
+                                "end_datetime": "{S1CADUS.end_datetime}",
+                                "satellite": "{S1CADUS.platform}",
+                                "dTa": 0,
+                                "dTb": 0,
+                            },
+                        },
+                    },
+                ],
+            },
+            {
+                "name": "S1CADUS",
+                "store_params": {"regex": r".*item\d"},
+            },
+        ],
+    }
+
+    # --- Unit config ---
+    unit = {
+        "input_products": [
+            {"name": "S1CADUS"},
+        ],
+    }
+
+    # --- Provided input products ---
+    provided_input_products = [
+        MagicMock(collection_name="stac_collection", item_id="item1"),
+        MagicMock(collection_name="stac_collection", item_id="item2"),
+    ]
+
+    # --- Call ---
+    ref_name, items = (
+        on_demand_processing._resolve_specific_input_product_stac_items(  # pylint:disable=protected-access
+            input_adfs,
+            task_table,
+            unit,
+            provided_input_products,
+            mock_rs_client,
+        )
+    )
+
+    # --- Assertions ---
+    assert ref_name == "S1CADUS"
+    assert items == ["item1", "item2"]
+
+    mock_logger.info.assert_any_call("ADFS multiplicity 'one_per_input' refers to input 'S1CADUS'")
+
+
 async def test_dpr_processing_raises_on_unstaged_adf(
     mocker,
     mocked_tasktable,  # /dpr/processes/mockup?...


### PR DESCRIPTION
Handle multiplicy == 'one_per_input' to support task tables requiring an ADFS per input product.

Real-case example: one ETAD per SLC for S1 ARD