### PR TITLE
RSPY-1050 - Allow to specify EOPF logging level in generic processing flow

### DIFF
--- a/rs_workflows/flow_utils.py
+++ b/rs_workflows/flow_utils.py
@@ -87,6 +87,16 @@ class AdfType(str, Enum):
     S00__ADF_ECMWA = "S00__ADF_ECMWA"
 
 
+class LoggingLevel(str, Enum):
+    """Logging level allowed by eopf.logging module"""
+
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+    CRITICAL = "CRITICAL"
+
+
 class FlowEnvArgs(BaseModel):
     """
     Prefect flow environment arguments.
@@ -256,6 +266,12 @@ class DprProcessIn(BaseModel):
         default=None,
         title="Dask Cluster Instance",
         description="Optional Dask cluster instance ID used to build a direct dashboard URL.",
+    )
+
+    logging_level: LoggingLevel = Field(
+        default=LoggingLevel.INFO,
+        title="Overall EOPF logging level",
+        description="Overall EOPF logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
     )
 
     s3_payload_file: str = Field(

--- a/rs_workflows/on_demand/common/l0_last_steps.py
+++ b/rs_workflows/on_demand/common/l0_last_steps.py
@@ -87,4 +87,5 @@ async def process_l0_last_steps(
             workflow=p.workflow,
             generated_product_to_collection_identifier=p.generated_product_to_collection_identifier or [],
             auxiliary_product_to_collection_identifier=p.auxiliary_product_to_collection_identifier or [],
+            logging_level=p.logging_level,
         )

--- a/rs_workflows/on_demand/common/types.py
+++ b/rs_workflows/on_demand/common/types.py
@@ -24,6 +24,7 @@ from rs_client.ogcapi.dpr_client import DprPipeline
 from rs_workflows.flow_utils import (
     AuxiliaryProductMapping,
     FlowGeneratedProduct,
+    LoggingLevel,
     Priority,
     ProcessingMode,
     WorkflowType,
@@ -88,6 +89,13 @@ class ProcessingFlowParams(BaseModel):
         title="Priority",
         description="Processing priority (low, normal, high).",
         json_schema_extra={"order": 8},
+    )
+
+    logging_level: LoggingLevel = Field(
+        default=LoggingLevel.INFO,
+        title="Overall EOPF logging level",
+        description="Overall EOPF logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
+        json_schema_extra={"order": 9},
     )
 
     processing_mode: list[ProcessingMode] = Field(

--- a/rs_workflows/payload_generator.py
+++ b/rs_workflows/payload_generator.py
@@ -39,6 +39,7 @@ from rs_workflows.payload_template import (
     GeneralConfiguration,
     InputProduct,
     IOConfig,
+    LoggingConfig,
     OutputProduct,
     PayloadSchema,
     StoreParams,
@@ -822,8 +823,8 @@ def generate_payload(  # pylint: disable=unused-argument
     # NOTE: The dask context is not built here, it will be updated by the dpr_service
     logger.info("Building the payload")
     payload = PayloadSchema(
-        # add some default params, as stated in a comment from jira (story 800)
-        general_configuration=GeneralConfiguration(),
+        # add some default params, as stated in a comment from jira (stories 800/1050)
+        general_configuration=GeneralConfiguration(logging=LoggingConfig(level=dpr_process_in.logging_level.name)),
         workflow=workflow_steps,
         io=io_config,  # type: ignore
         # The dask_context section is built in the dpr_service

--- a/rs_workflows/utils/dpr.py
+++ b/rs_workflows/utils/dpr.py
@@ -30,6 +30,7 @@ from rs_workflows.flow_utils import (
     FlowEnvArgs,
     FlowGeneratedProduct,
     FlowInputProduct,
+    LoggingLevel,
     Priority,
     ProcessingMode,
     WorkflowType,
@@ -61,6 +62,7 @@ async def call_dpr_flow(
     workflow: WorkflowType | None,
     generated_product_to_collection_identifier: list[FlowGeneratedProduct],
     auxiliary_product_to_collection_identifier: list[AuxiliaryProductMapping],
+    logging_level: LoggingLevel = LoggingLevel.INFO,
 ) -> None:
     """
     Call any DPR processing flow with a set of default parameters.
@@ -82,6 +84,7 @@ async def call_dpr_flow(
         input_products=input_products,
         generated_product_to_collection_identifier=generated_product_to_collection_identifier,
         auxiliary_product_to_collection_identifier=auxiliary_product_to_collection_identifier,
+        logging_level=logging_level,
         processing_mode=processing_mode,
         **external_variables,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,7 @@ from rs_workflows.flow_utils import (
     FlowEnvArgs,
     FlowGeneratedProduct,
     FlowInputProduct,
+    LoggingLevel,
 )
 from rs_workflows.payload_generator import RSPY_CATALOG_BUCKET
 from rs_workflows.payload_template import (  # StoreOptionsWrapper,
@@ -901,6 +902,8 @@ def _mock_dpr_process_in():
     msg = MagicMock()
     msg.value = "TEST_PROCESSOR"
     mock.processor_name = msg
+
+    mock.logging_level = LoggingLevel.DEBUG
 
     return mock
 


### PR DESCRIPTION
Add a new processing flow parameter:

<img width="536" height="352" alt="image" src="https://github.com/user-attachments/assets/537d95bf-531a-4186-9255-c3ea22027824" />

that translates to:
```yaml
{
  "slcs": [
    "S01SIWSLC_20260327T174632_0026_C132_TF72",
    "S01SIWSLC_20260408T174632_0026_C132_TFC6",
    "S01SIWSLC_20260420T055953_0026_D110_TD47"
  ],
  "flow_params": {
    "unit": "Calibration",
    "logging_level": "INFO",
    "owner_identifier": "copernicus",
    "input_collections": [
      "s01siwslc"
    ],
    "dask_cluster_label": "dask-s1ard.vprivat.feat-rspy1025-new-s1-ard",
  },
  "reference_date": "2026-04-08"
}
```