### PR TITLE
RSPY-1047 - Handle ADFS of type 'folder' correctly

### DIFF
--- a/rs_workflows/on_demand_processing.py
+++ b/rs_workflows/on_demand_processing.py
@@ -152,7 +152,7 @@ def _get_archived_item_indexes(item_collection) -> list[int]:
     return archived_indexes
 
 
-async def _normalize_archived_auxip_items(item_collection, dpr_input):
+async def _normalize_archived_auxip_items(item_collection: ItemCollection, dpr_input: DprProcessIn) -> ItemCollection:
     """
     Normalize archived AUXIP items and persist the updated metadata to the catalog.
 
@@ -208,7 +208,7 @@ async def _stage_input_adfs_alternative(
     specific_input_product: tuple[str | None, Item | None] = (None, None),
     staging_retries: int = 3,
     staging_retry_delay: int = 60,
-):
+) -> tuple[str, str, tuple[bool, ItemCollection]] | None:
     """
     Stage one ADFS alternative and normalize archived outputs when needed.
 
@@ -254,7 +254,7 @@ async def _stage_input_adfs_alternative(
     logger.info(f"Finished processing input ADFS, ItemCollection size: {len(item_collection.items)}")
     logger.debug(f"Finished processing input ADFS, ItemCollection: {item_collection.to_dict()}")
 
-    return input_adfs["name"], (auxip_status, item_collection)
+    return input_adfs["name"], input_adfs["type"], (auxip_status, item_collection)
 
 
 @task(name="Process input ADFS")
@@ -265,7 +265,7 @@ async def process_input_adfs(
     specific_input_product: tuple[str | None, Item | None] = (None, None),
     staging_retries: int = 3,
     staging_retry_delay: int = 60,
-):
+) -> tuple[str, str, tuple[bool, ItemCollection]]:
     """
     Stage the ADFS inputs described in the task table for one processing unit input.
 
@@ -282,8 +282,8 @@ async def process_input_adfs(
       generation sees the final asset hrefs
 
     Returns:
-        tuple[str, tuple[bool, Any]]:
-            The input ADFS name together with the original staging status/item
+        tuple[str, str, tuple[bool, ItemCollection]]:
+            The input ADFS name and type together with the original staging status/item
             collection tuple shape expected by downstream code.
 
     Raises:
@@ -455,16 +455,17 @@ async def dpr_processing(
                     )
 
         try:
-            auxip_items = [t.result() for t in tasks]
+            auxip_items: list[tuple[str, str, tuple[bool, ItemCollection]]] = [t.result() for t in tasks]
         except (RuntimeError, KeyError) as err:
             raise err
 
-        adfs: set[tuple[str, str]] = set()
-        for name, (status, item_collection) in auxip_items:  # type: ignore
-            for item in item_collection.items:  # type: ignore
-                if status:  # type: ignore
+        # Set of ADFS. Each tuple includes the adfs name, type and the s3 storage path
+        adfs: set[tuple[str, str, str]] = set()
+        for name, adf_type, (status, item_collection) in auxip_items:
+            for item in item_collection.items:
+                if status:
                     asset = next(iter(item.assets.values()))
-                    adfs.add((name, asset.href))  # type: ignore
+                    adfs.add((name, adf_type, asset.href))
                 else:
                     raise ValueError(f"The adf input files {next(iter(item.assets.values()))} was not correctly staged")
         # generate the dpr payload file

--- a/rs_workflows/payload_generator.py
+++ b/rs_workflows/payload_generator.py
@@ -556,7 +556,7 @@ def get_io(
 
 def build_adfs(
     storage_configuration: StorageConfig,
-    adfs: list[tuple[str, str]],
+    adfs: list[tuple[str, str, str]],
 ) -> list[AdfConfig]:
     """
     Build a list of AdfConfig objects from input ADF definitions.
@@ -569,7 +569,7 @@ def build_adfs(
     Args:
         storage_configuration (StorageConfig): Configuration object used to
             retrieve default storage parameters.
-        adfs (list[tuple[str, str]]): List of (adf_id, path) tuples.
+        adfs (list[tuple[str, str, str]]): List of (adf_id, adfs_type, path) tuples.
 
     Returns:
         list[AdfConfig]: List of constructed AdfConfig objects, one per group
@@ -579,18 +579,22 @@ def build_adfs(
 
     # Group adfs by name (needed for adfs of type regex)
     grouped_adfs = defaultdict(list)
-    for adf in adfs:
-        grouped_adfs[adf[0]].append(adf[1])
+    for adf_id, adfs_type, path in adfs:
+        grouped_adfs[adf_id].append((path, adfs_type))
 
     # Iterate over each group of adfs
-    for adfs_id, adfs_paths in grouped_adfs.items():
+    for adfs_id, adfs_entries in grouped_adfs.items():
         adfs_name = storage_configuration.default_adfs_storage
         store_params = deepcopy(storage_configuration.get_store_params(adfs_name))
-        if len(adfs_paths) == 1:
+        if len(adfs_entries) == 1:
             # Standard case where each adfs has a different id (i.e. single file)
-            result.append(AdfConfig(id=adfs_id, path=adfs_paths[0], store_params=store_params))
+            path, adfs_type = adfs_entries[0]
+            if adfs_type == "folder":
+                path = os.path.dirname(path)
+            result.append(AdfConfig(id=adfs_id, path=path, store_params=store_params))
         elif isinstance(store_params, StoreParams):
             # Advanced case where several adfs share the same id (i.e. several files)
+            adfs_paths = [p for p, _ in adfs_entries]
             store_params.multiplicity = str(len(adfs_paths))
             # Compute longest common prefix
             common_folder, relative_parts = get_common_and_relative_paths(adfs_paths)
@@ -713,7 +717,7 @@ def build_mockup_payload(owner_id):
 def generate_payload(  # pylint: disable=unused-argument
     flow_env: FlowEnv,
     unit_list: list[dict],
-    adfs: list[tuple[str, str]],
+    adfs: list[tuple[str, str, str]],
     dpr_process_in: DprProcessIn,
 ) -> PayloadSchema:
     """
@@ -728,8 +732,8 @@ def generate_payload(  # pylint: disable=unused-argument
             credentials, tracing, and runtime context.
         unit_list (list[dict]): List of workflow unit definitions containing I/O
             specifications and processing parameters.
-        adfs (list[tuple[str, str]]): List of auxiliary item
-            tuples, where each tuple includes the eopf type and the s3 storage path.
+        adfs (list[tuple[str, str, str]]): List of auxiliary item
+            tuples, where each tuple includes the adfs name, the adfs type and the s3 storage path.
         dpr_process_in (DprProcessIn): DPR input process definition containing
             product paths and parameters.
 

--- a/tests/test_payload_generator.py
+++ b/tests/test_payload_generator.py
@@ -26,6 +26,7 @@ from rs_workflows.flow_utils import (
     FlowInputProduct,
 )
 from rs_workflows.payload_generator import (  # load_store_params_from_config,
+    build_adfs,
     build_input_products,
     build_output_products,
     build_workflow_step,
@@ -223,7 +224,7 @@ def test_generate_payload_success(
     payload = generate_payload.fn(
         flow_env=flow_env,
         unit_list=[sample_unit],
-        adfs=[("ADF1", "s3://bucket/adf1")],
+        adfs=[("ADF1", "filename", "s3://bucket/adf1")],
         dpr_process_in=mock_dpr_process_in,
     )
 
@@ -243,7 +244,7 @@ def test_generate_payload_success(
     payload = generate_payload.fn(
         flow_env=flow_env,
         unit_list=[sample_unit],
-        adfs=[("ADF1", "s3://bucket/adf1")],
+        adfs=[("ADF1", "filename", "s3://bucket/adf1")],
         dpr_process_in=mock_dpr_process_in,
     )
     assert payload.logging == expected_logging
@@ -685,6 +686,68 @@ def test_build_input_products_fallback_storage_pipeline(sample_unit, mock_store_
     mock_storage.get_storage_for_pipeline_section.assert_any_call("pipeline_input_1")
     mock_storage.get_storage_for_pipeline_section.assert_any_call("other")
     mock_storage.get_store_params.assert_called_with("pipeline_s3")
+
+
+# ----------------------------------------------------------------------
+
+# build_adfs
+
+
+def test_build_adfs_single_folder(mock_store_params):
+    """Test ADFS of type 'folder' with a single file"""
+    mock_storage_config = MagicMock()
+    mock_storage_config.get_store_params.return_value = mock_store_params
+    mock_storage_config.default_adfs_storage = "s3"
+
+    adfs = [
+        ("adf1", "folder", "/data/myfolder/file1.txt"),
+    ]
+
+    result = build_adfs(mock_storage_config, adfs)
+
+    assert len(result) == 1
+    assert result[0].id == "adf1"
+    assert result[0].path == "/data/myfolder"
+
+
+def test_build_adfs_single_filename(mock_store_params):
+    """Test ADFS of type 'filename' with a single file"""
+    mock_storage_config = MagicMock()
+    mock_storage_config.get_store_params.return_value = mock_store_params
+    mock_storage_config.default_adfs_storage = "s3"
+
+    adfs = [
+        ("adf1", "filename", "/data/file1.txt"),
+    ]
+
+    result = build_adfs(mock_storage_config, adfs)
+
+    assert len(result) == 1
+    assert result[0].id == "adf1"
+    assert result[0].path == "/data/file1.txt"
+
+
+def test_build_adfs_multiple_entries(mock_store_params):
+    """Test ADFS with multiple files"""
+    mock_storage_config = MagicMock()
+    mock_storage_config.get_store_params.return_value = mock_store_params
+    mock_storage_config.default_adfs_storage = "s3"
+
+    adfs = [
+        ("adf1", "filename", "/data/folder/file1.txt"),
+        ("adf1", "filename", "/data/folder/file2.txt"),
+    ]
+
+    result = build_adfs(mock_storage_config, adfs)
+
+    assert len(result) == 1
+    adf = result[0]
+
+    assert adf.id == "adf1"
+    assert adf.path == "/data/folder/"
+    assert isinstance(adf.store_params, StoreParams)
+    assert adf.store_params.multiplicity == "2"
+    assert adf.store_params.regex == r"(file1\.txt|file2\.txt)"
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -425,7 +425,7 @@ async def test_dpr_processing_raises_on_unstaged_adf(
                 datetime=datetime.now(),
             )
             it.add_asset("data", Asset(href=f"s3://{MOCKED_BUCKET}/unstaged1.bin"))
-            return ("ADFS_NAME", (False, ItemCollection([it])))
+            return ("ADFS_NAME", "filename", (False, ItemCollection([it])))
 
     class ProcessInputAdfsTaskFailMock(Mock):
         """Mock of process_input_adfs to force status=False in the flow."""


### PR DESCRIPTION
S1-ARD requires "ORBIT" adfs to be a folder, even if it contains a single file.