### PR TITLE
Fix: ADFS input names in uppercase in tasktables

### DIFF
--- a/tests/resources/TaskTable_S1_L0_generated_by_rs_python_v1.json
+++ b/tests/resources/TaskTable_S1_L0_generated_by_rs_python_v1.json
@@ -35,12 +35,12 @@
       ],
       "input_adfs": [
         {
-          "name": "OSF",
+          "name": "osf",
           "mode": "always",
           "mandatory": false
         },
         {
-          "name": "FRO",
+          "name": "fro",
           "mode": "always",
           "mandatory": false
         }
@@ -62,7 +62,7 @@
       "store_type": "cadu"
     },
     {
-      "name": "OSF",
+      "name": "osf",
       "type": "filename",
       "store_type": "safe",
       "alternatives": [
@@ -83,7 +83,7 @@
       ]
     },
     {
-      "name": "FRO",
+      "name": "fro",
       "type": "filename",
       "store_type": "safe",
       "alternatives": [

--- a/tests/resources/TaskTable_S3_L0_generated_by_rs_python_v1.json
+++ b/tests/resources/TaskTable_S3_L0_generated_by_rs_python_v1.json
@@ -35,12 +35,12 @@
       ],
       "input_adfs": [
         {
-          "name": "OSF",
+          "name": "osf",
           "mode": "always",
           "mandatory": false
         },
         {
-          "name": "FRO",
+          "name": "fro",
           "mode": "always",
           "mandatory": false
         }
@@ -68,7 +68,7 @@
       "store_type": "cadu"
     },
     {
-      "name": "OSF",
+      "name": "osf",
       "type": "filename",
       "store_type": "safe",
       "alternatives": [
@@ -89,7 +89,7 @@
       ]
     },
     {
-      "name": "FRO",
+      "name": "fro",
       "type": "filename",
       "store_type": "safe",
       "alternatives": [

--- a/tests/resources/TaskTable_S3_L0_satellite_generated_by_rs_python_v1.json
+++ b/tests/resources/TaskTable_S3_L0_satellite_generated_by_rs_python_v1.json
@@ -36,12 +36,12 @@
       ],
       "input_adfs": [
         {
-          "name": "OSF",
+          "name": "osf",
           "mode": "always",
           "mandatory": false
         },
         {
-          "name": "FRO",
+          "name": "fro",
           "mode": "always",
           "mandatory": false
         }
@@ -69,7 +69,7 @@
       "store_type": "cadu"
     },
     {
-      "name": "OSF",
+      "name": "osf",
       "type": "filename",
       "store_type": "safe",
       "alternatives": [
@@ -91,7 +91,7 @@
       ]
     },
     {
-      "name": "FRO",
+      "name": "fro",
       "type": "filename",
       "store_type": "safe",
       "alternatives": [

--- a/tests/resources/tasktable.json
+++ b/tests/resources/tasktable.json
@@ -35,12 +35,12 @@
       ],
       "input_adfs": [
         {
-          "name": "OSF",
+          "name": "osf",
           "mode": "always",
           "mandatory": false
         },
         {
-          "name": "FRO",
+          "name": "fro",
           "mode": "always",
           "mandatory": false
         }
@@ -62,7 +62,7 @@
       "store_type": "cadu"
     },
     {
-      "name": "OSF",
+      "name": "osf",
       "type": "filename",
       "store_type": "safe",
       "alternatives": [
@@ -83,7 +83,7 @@
       ]
     },
     {
-      "name": "FRO",
+      "name": "fro",
       "type": "filename",
       "store_type": "safe",
       "alternatives": [

--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -509,7 +509,7 @@ def test_case_s1_l0_exact_output_with_regex():
             ],
             "input_adfs": [
                 {
-                    "name": "OSF",
+                    "name": "osf",
                     "mandatory": False,
                     "type": "filename",
                     "store_type": "safe",
@@ -531,7 +531,7 @@ def test_case_s1_l0_exact_output_with_regex():
                     ],
                 },
                 {
-                    "name": "FRO",
+                    "name": "fro",
                     "mandatory": False,
                     "type": "filename",
                     "store_type": "safe",


### PR DESCRIPTION
Fix to have ADFS input names in lowercase in the tasktables, instead of uppercase.