### PR TITLE
RSPY-860 - S1 ARD: Support reading DEM directly from earthdatahub

### DIFF
--- a/config/storage_configuration.json
+++ b/config/storage_configuration.json
@@ -35,6 +35,10 @@
         "storage": "s3-dem-s1"
       },
       {
+        "product_name": "DEM",
+        "storage": "s3"
+      },
+      {
         "product_name": "Orbit",
         "storage": "shared_disk"
       }

--- a/rs_client/stac/earthdatahub_client.py
+++ b/rs_client/stac/earthdatahub_client.py
@@ -1,0 +1,60 @@
+# Copyright 2023-2026 Airbus, CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""EarthDataHubClient class implementation."""
+
+import logging
+from typing import Any
+
+from rs_client.stac.stac_base import StacBase
+
+EDH_STAC_HREF = "https://earthdatahub.destine.eu/api/stac/v1"
+
+
+class EarthDataHubClient(StacBase):
+    """
+    EarthDataHubClient class implementation.
+
+    Attributes: see :py:class:`RsClient`
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments, too-many-positional-arguments
+        self,
+        edh_api_key: str | None = None,  # pylint: disable=unused-argument
+        logger: logging.Logger | None = None,
+        **kwargs: dict[str, Any],
+    ):
+        """
+        Initializes an EarthDataHubClient instance.
+
+        Args:
+            edh_api_key (str | None): API key for authentication (default: None).
+            logger (logging.Logger | None, optional): Logger instance (default: None).
+            **kwargs: Arbitrary keyword arguments that may include:
+                - `headers` (Optional[Dict[str, str]])
+                - `parameters` (Optional[Dict[str, Any]])
+                - `ignore_conformance` (Optional[bool])
+                - `modifier` (Callable[[Collection | Item | ItemCollection | dict[Any, Any]], None] | None)
+                - `request_modifier` (Optional[Callable[[Request], Union[Request, None]]])
+                - `stac_io` (Optional[StacApiIO])
+                - `timeout` (Optional[Timeout])
+        """
+        super().__init__(None, None, None, logger, EDH_STAC_HREF, **kwargs)
+
+    @property
+    def href_service(self) -> str:
+        """
+        Return the EarthDataHub STAC URL.
+        """
+        return EDH_STAC_HREF

--- a/rs_client/stac/stac_base.py
+++ b/rs_client/stac/stac_base.py
@@ -361,7 +361,17 @@ class StacBase(RsClient):
         """
         kwargs.pop("owner_id", None)
         kwargs["datetime"] = kwargs.pop("timestamp", None)
-        kwargs["filter"] = kwargs.pop("stac_filter", None)
+        stac_filter = kwargs.pop("stac_filter", None)
+        if (
+            isinstance(stac_filter, dict)
+            and stac_filter.get("op", "") == "="
+            and len(stac_filter.get("args", [])) == 2
+            and stac_filter["args"][0] == {"property": "id"}
+        ):
+            # Optim/Fix required for EarthDataHub
+            kwargs["ids"] = stac_filter["args"][1]
+        else:
+            kwargs["filter"] = stac_filter
         self.logger.info(f"🔍 Performing STAC search with parameters: {kwargs}")
 
         try:

--- a/rs_workflows/auxip_flow.py
+++ b/rs_workflows/auxip_flow.py
@@ -21,11 +21,11 @@ from prefect import flow, get_run_logger, task
 from prefect.artifacts import acreate_markdown_artifact
 from pystac import Item, ItemCollection
 
-from rs_client.stac.auxip_client import AuxipClient
 from rs_client.stac.catalog_client import CatalogClient
 from rs_common.utils import create_valcover_filter
 from rs_workflows.flow_utils import FlowEnv, FlowEnvArgs
 from rs_workflows.staging_flow import staging_task
+from rs_workflows.utils import stac
 from rs_workflows.utils.utils import asset_unzip_decompress
 
 ###############
@@ -47,26 +47,13 @@ async def search(
         auxip_cql2: Auxip CQL2 filter read from the processor tasktable.
         error_if_empty: Raise a ValueError if the results are empty.
     """
-    logger = get_run_logger()
-
-    # Init flow environment and opentelemetry span
-    flow_env = FlowEnv(env)
-    with flow_env.start_span(__name__, "auxip-search"):
-
-        logger.info(f"Start Auxip search: {auxip_cql2}")
-        auxip_client: AuxipClient = flow_env.rs_client.get_auxip_client()
-        found = auxip_client.search(
-            method="POST",
-            stac_filter=auxip_cql2.get("filter"),
-            max_items=auxip_cql2.get("limit"),
-            sortby=auxip_cql2.get("sortby"),
-        )
-        if (not found) and error_if_empty:
-            raise ValueError(
-                f"❌ No Auxip product found for CQL2 filter: {json.dumps(auxip_cql2, indent=2)}",
-            )
-        logger.info(f"🔍 Auxip search found {len(found)} result(s): {found.to_dict()}")
-        return found
+    return await stac.search(
+        env,
+        auxip_cql2,
+        "auxip-search",
+        lambda rs_client: rs_client.get_auxip_client(),
+        error_if_empty,
+    )
 
 
 @flow(name="stage-auxip")

--- a/rs_workflows/earthdatahub_flow.py
+++ b/rs_workflows/earthdatahub_flow.py
@@ -1,0 +1,54 @@
+# Copyright 2023-2026 Airbus, CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""EarthDataHub flow implementation."""
+
+from prefect import flow, task
+from pystac import ItemCollection
+
+from rs_client.stac.earthdatahub_client import EarthDataHubClient
+from rs_workflows.flow_utils import FlowEnvArgs
+from rs_workflows.utils import stac
+
+######################
+# EarthDataHub flows #
+######################
+
+
+@flow(name="search-earthdatahub")
+async def search(
+    env: FlowEnvArgs,
+    edh_cql2: dict,
+    error_if_empty: bool = False,
+) -> ItemCollection | None:
+    """
+    Search STAC products in EarthDataHub catalogue.
+
+    Args:
+        env: Prefect flow environment (at least the owner_id is required)
+        edh_cql2: CQL2 filter read from the processor tasktable.
+        error_if_empty: Raise a ValueError if the results are empty.
+    """
+    return await stac.search(env, edh_cql2, "earthdatahub-search", lambda _: EarthDataHubClient(), error_if_empty)
+
+
+###########################
+# Call the flows as tasks #
+###########################
+
+
+@task(name="search-earthdatahub")
+async def earthdatahub_search_task(*args, **kwargs) -> ItemCollection | None:
+    """See: search"""
+    return await search.fn(*args, **kwargs)

--- a/rs_workflows/flow_utils.py
+++ b/rs_workflows/flow_utils.py
@@ -384,6 +384,12 @@ class DprProcessIn(BaseModel):
         description="Instrument mode used in certain queries. Can be a string or InstrumentMode enum.",
     )
 
+    edh_api_key: str | None = Field(
+        default=None,
+        title="EarthDataHub Standard API key",
+        description="Destination Earth / EarthDataHub standard API key used to access Copernicus DEM",
+    )
+
     # -----------------------
     # Validators
     # -----------------------

--- a/rs_workflows/on_demand_processing.py
+++ b/rs_workflows/on_demand_processing.py
@@ -34,7 +34,7 @@ from rs_client.ogcapi.dpr_client import ClusterInfo
 from rs_client.rs_client import RsClient
 from rs_client.stac.catalog_client import CatalogClient
 from rs_common import prefect_utils
-from rs_workflows import auxip_flow, catalog_flow
+from rs_workflows import auxip_flow, catalog_flow, earthdatahub_flow
 from rs_workflows.dpr_flow import run_processor
 from rs_workflows.flow_utils import (
     DprProcessIn,
@@ -216,18 +216,26 @@ async def _stage_input_adfs_alternative(
         task_table,
         specific_input_product,
     )
-    logger.info(f"Selected ADFS collection {collection}")
+    logger.info(f"Selected ADFS collection {collection} for ADFS {input_adfs["name"]}")
 
     auxip_status: bool
     auxip_items: ItemCollection | None
-    auxip_status, auxip_items = (
-        auxip_flow.auxip_staging_task.with_options(
-            retries=staging_retries,
-            retry_delay_seconds=staging_retry_delay,
+    # Special case for Copernicus DEM available at Earthdatahub
+    if input_adfs["name"] == "DEM":
+        auxip_items = earthdatahub_flow.earthdatahub_search_task.submit(
+            dpr_input.env,
+            auxip_cql2,
+        ).result()
+        auxip_status = True
+    else:
+        auxip_status, auxip_items = (
+            auxip_flow.auxip_staging_task.with_options(
+                retries=staging_retries,
+                retry_delay_seconds=staging_retry_delay,
+            )
+            .submit(dpr_input.env, auxip_cql2, collection, timeout)
+            .result()
         )
-        .submit(dpr_input.env, auxip_cql2, collection, timeout)
-        .result()  # type: ignore
-    )
 
     if not auxip_items:
         return None
@@ -448,7 +456,7 @@ async def dpr_processing(
             auxip_items: list[tuple[str, str, tuple[bool, ItemCollection]]] = [t.result() for t in tasks]
         except (RuntimeError, KeyError) as err:
             raise err
-        # Set of ADFS. Each tuple includes the adfs name, type and the s3 storage path
+        # Set of ADFS. Each tuple includes the adfs name, type and the s3/https storage path
         source_items: list[Item] = []
         adfs: set[tuple[str, str, str]] = set()
         for name, adf_type, (status, item_collection) in auxip_items:
@@ -458,6 +466,7 @@ async def dpr_processing(
 
                 if status:
                     asset = next(iter(item.assets.values()))
+                    logger.info(f"ADFS '{name}' of type '{adf_type}': {asset.href}")
                     adfs.add((name, adf_type, asset.href))
                 else:
                     raise ValueError(f"The adf input files {next(iter(item.assets.values()))} was not correctly staged")

--- a/rs_workflows/payload_generator.py
+++ b/rs_workflows/payload_generator.py
@@ -25,6 +25,7 @@ from uuid import uuid4
 import requests
 from prefect import get_run_logger, task
 from prefect.blocks.system import Secret
+from pydantic import SecretStr
 from pystac import Item
 
 from rs_client.ogcapi.dpr_client import DprProcessor
@@ -51,6 +52,7 @@ from rs_workflows.utils.utils import get_common_and_relative_paths, search_by_na
 FILEPATH_ENV_VAR = "BUCKET_CONFIG_FILE_PATH"
 DEFAULT_FILEPATH = "/app/conf/expiration_bucket.csv"
 RSPY_CATALOG_BUCKET = "rs-dev-cluster-catalog"
+DATA_EDH_DOMAIN = "data.earthdatahub.destine.eu"
 
 CONFIG_DIR = Path(__file__).parent.parent / "config"
 
@@ -367,6 +369,10 @@ def build_input_products(
                 store_name = storage_configuration.get_storage_for_pipeline_section(
                     mapping.get("origin", ""),
                 ) or storage_configuration.get_storage_for_pipeline_section("other")
+                # TODO: the following line is temporary and for tests only ! Force eveything to s3 !
+                # Delete the following line once the things will be clarified with other store_names
+                # This is due to the internal discussions, disregard any other store_name but s3
+                store_name = "s3"
         if not store_name:
             raise RuntimeError(f"Couldn't find any storage configuration for input product '{product_name}'")
         store_params = deepcopy(storage_configuration.get_store_params(store_name))
@@ -564,6 +570,7 @@ def get_io(
 def build_adfs(
     storage_configuration: StorageConfig,
     adfs: list[tuple[str, str, str]],
+    dpr_process_in: DprProcessIn,
 ) -> list[AdfConfig]:
     """
     Build a list of AdfConfig objects from input ADF definitions.
@@ -577,6 +584,7 @@ def build_adfs(
         storage_configuration (StorageConfig): Configuration object used to
             retrieve default storage parameters.
         adfs (list[tuple[str, str, str]]): List of (adf_id, adfs_type, path) tuples.
+        dpr_process_in (DprProcessIn): DPR input process definition
 
     Returns:
         list[AdfConfig]: List of constructed AdfConfig objects, one per group
@@ -598,6 +606,12 @@ def build_adfs(
             path, adfs_type = adfs_entries[0]
             if adfs_type == "folder":
                 path = os.path.dirname(path)
+            # Inject EarthDataHub API Key in path, as per documentation at
+            # https://earthdatahub.destine.eu/collections/copernicus-dem/datasets/GLO-30
+            if dpr_process_in.edh_api_key and path.startswith(f"https://{DATA_EDH_DOMAIN}/"):
+                path = SecretStr(
+                    path.replace(DATA_EDH_DOMAIN, f"edh:{dpr_process_in.edh_api_key}@api.earthdatahub.destine.eu"),
+                )
             result.append(AdfConfig(id=adfs_id, path=path, store_params=store_params))
         elif isinstance(store_params, StoreParams):
             # Advanced case where several adfs share the same id (i.e. several files)
@@ -801,7 +815,7 @@ def generate_payload(  # pylint: disable=unused-argument
             raise ValueError(f"Key {ke} not found in unit list") from ke
 
     logger.info("Building ADFs section")
-    io_config.adfs = build_adfs(storage_configuration, adfs)
+    io_config.adfs = build_adfs(storage_configuration, adfs, dpr_process_in)
 
     # Add the logging config for l0 and s1 / s3 configurations. These configurations
     # are hardcoded in the l0 eopf dask worker image. The path where these files are stored is given

--- a/rs_workflows/payload_template.py
+++ b/rs_workflows/payload_template.py
@@ -279,7 +279,7 @@ class AdfConfig(BasePayloadModel):
     """Definition of an ADF configuration entry"""
 
     id: str
-    path: str
+    path: str | SecretStr
     store_params: StoreParams | None = None
 
 

--- a/rs_workflows/utils/stac.py
+++ b/rs_workflows/utils/stac.py
@@ -1,0 +1,63 @@
+# Copyright 2023-2026 Airbus, CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""STAC utilities"""
+
+import json
+from collections.abc import Callable
+
+from prefect import get_run_logger
+from pystac import ItemCollection
+
+from rs_client.rs_client import RsClient
+from rs_client.stac.stac_base import StacBase
+from rs_workflows.flow_utils import FlowEnv, FlowEnvArgs
+
+
+async def search(
+    env: FlowEnvArgs,
+    cql2: dict,
+    span_name: str,
+    stac_client_getter: Callable[[RsClient], StacBase],
+    error_if_empty: bool = False,
+) -> ItemCollection | None:
+    """
+    Search items in a STAC catalogue.
+
+    Args:
+        env: Prefect flow environment (at least the owner_id is required)
+        cql2: CQL2 filter read from the processor tasktable.
+        stac_client_getter: Function receiving rs_client and returning a StacBase.
+        error_if_empty: Raise a ValueError if the results are empty.
+    """
+    logger = get_run_logger()
+
+    # Init flow environment and opentelemetry span
+    flow_env = FlowEnv(env)
+    with flow_env.start_span(__name__, span_name):
+
+        logger.info(f"Start STAC search using CQL2: {cql2}")
+        stac_client: StacBase = stac_client_getter(flow_env.rs_client)
+        found = stac_client.search(
+            method="POST",
+            stac_filter=cql2.get("filter"),
+            max_items=cql2.get("limit"),
+            sortby=cql2.get("sortby"),
+        )
+        if (not found) and error_if_empty:
+            raise ValueError(
+                f"No item found for CQL2: {json.dumps(cql2, indent=2)}",
+            )
+        logger.info(f"STAC search found {len(found)} result(s): {found.to_dict()}")
+        return found

--- a/tests/test_auxip_flow.py
+++ b/tests/test_auxip_flow.py
@@ -32,6 +32,7 @@ def mock_auxip_logger(monkeypatch, mocker):
     """Replace Prefect run logger with a plain mock."""
     logger = mocker.Mock()
     monkeypatch.setattr(auxip_flow, "get_run_logger", lambda: logger)
+    monkeypatch.setattr(auxip_flow.stac, "get_run_logger", lambda: logger)
     return logger
 
 
@@ -45,7 +46,7 @@ async def test_search_returns_found_items(monkeypatch, mocker, mock_auxip_logger
     flow_env = mocker.Mock()
     flow_env.start_span.return_value = nullcontext()
     flow_env.rs_client.get_auxip_client.return_value = auxip_client
-    monkeypatch.setattr(auxip_flow, "FlowEnv", lambda env: flow_env)
+    monkeypatch.setattr(auxip_flow.stac, "FlowEnv", lambda env: flow_env)
 
     result = await auxip_flow.search.fn(env, {"filter": {"foo": "bar"}, "limit": 3, "sortby": []})
 
@@ -62,9 +63,9 @@ async def test_search_raises_when_empty_and_error_if_empty(monkeypatch, mocker, 
     flow_env = mocker.Mock()
     flow_env.start_span.return_value = nullcontext()
     flow_env.rs_client.get_auxip_client.return_value = auxip_client
-    monkeypatch.setattr(auxip_flow, "FlowEnv", lambda env: flow_env)
+    monkeypatch.setattr(auxip_flow.stac, "FlowEnv", lambda env: flow_env)
 
-    with pytest.raises(ValueError, match="No Auxip product found"):
+    with pytest.raises(ValueError, match="No item found for CQL2"):
         await auxip_flow.search.fn(env, {"filter": {"foo": "bar"}}, error_if_empty=True)
 
 

--- a/tests/test_payload_generator.py
+++ b/tests/test_payload_generator.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import SecretStr
 from pystac import Asset, Item
 
 from rs_client.ogcapi.dpr_client import DprProcessor
@@ -26,6 +27,7 @@ from rs_workflows.flow_utils import (
     FlowInputProduct,
 )
 from rs_workflows.payload_generator import (  # load_store_params_from_config,
+    DATA_EDH_DOMAIN,
     build_adfs,
     build_input_products,
     build_output_products,
@@ -724,12 +726,20 @@ def test_build_input_products_fallback_storage_pipeline(sample_unit, mock_store_
     assert len(inputs) == 1
     mock_storage.get_storage_for_pipeline_section.assert_any_call("pipeline_input_1")
     mock_storage.get_storage_for_pipeline_section.assert_any_call("other")
-    mock_storage.get_store_params.assert_called_with("pipeline_s3")
+    # store_name is forced to "s3" regardless of the pipeline resolution (temporary workaround)
+    mock_storage.get_store_params.assert_called_with("s3")
 
 
 # ----------------------------------------------------------------------
 
 # build_adfs
+
+
+def _make_dpr_process_in(edh_api_key=None):
+    """Helper to create a minimal DprProcessIn mock for build_adfs tests."""
+    mock = MagicMock()
+    mock.edh_api_key = edh_api_key
+    return mock
 
 
 def test_build_adfs_single_folder(mock_store_params):
@@ -742,7 +752,7 @@ def test_build_adfs_single_folder(mock_store_params):
         ("adf1", "folder", "/data/myfolder/file1.txt"),
     ]
 
-    result = build_adfs(mock_storage_config, adfs)
+    result = build_adfs(mock_storage_config, adfs, _make_dpr_process_in())
 
     assert len(result) == 1
     assert result[0].id == "adf1"
@@ -759,7 +769,7 @@ def test_build_adfs_single_filename(mock_store_params):
         ("adf1", "filename", "/data/file1.txt"),
     ]
 
-    result = build_adfs(mock_storage_config, adfs)
+    result = build_adfs(mock_storage_config, adfs, _make_dpr_process_in())
 
     assert len(result) == 1
     assert result[0].id == "adf1"
@@ -777,7 +787,7 @@ def test_build_adfs_multiple_entries(mock_store_params):
         ("adf1", "filename", "/data/folder/file2.txt"),
     ]
 
-    result = build_adfs(mock_storage_config, adfs)
+    result = build_adfs(mock_storage_config, adfs, _make_dpr_process_in())
 
     assert len(result) == 1
     adf = result[0]
@@ -787,6 +797,75 @@ def test_build_adfs_multiple_entries(mock_store_params):
     assert isinstance(adf.store_params, StoreParams)
     assert adf.store_params.multiplicity == "2"
     assert adf.store_params.regex == r"(file1\.txt|file2\.txt)"
+
+
+def test_build_adfs_edh_url_replaced_with_api_key(mock_store_params):
+    """EDH URL is rewritten to inject the API key and becomes a SecretStr."""
+    mock_storage_config = MagicMock()
+    mock_storage_config.get_store_params.return_value = mock_store_params
+    mock_storage_config.default_adfs_storage = "s3"
+
+    edh_url = f"https://{DATA_EDH_DOMAIN}/copernicus-dem-30m/tile.tif"
+    adfs = [("DEM", "filename", edh_url)]
+
+    result = build_adfs(mock_storage_config, adfs, _make_dpr_process_in(edh_api_key="my-secret-token"))
+
+    assert len(result) == 1
+    path = result[0].path
+    assert isinstance(path, SecretStr), "EDH path with injected API key must be a SecretStr"
+    full_url = path.get_secret_value()
+    assert "my-secret-token" in full_url
+    assert DATA_EDH_DOMAIN not in full_url
+    assert full_url == "https://edh:my-secret-token@api.earthdatahub.destine.eu/copernicus-dem-30m/tile.tif"
+
+
+def test_build_adfs_edh_url_secret_hides_token(mock_store_params):
+    """The SecretStr representation must not expose the API key in plain text."""
+    mock_storage_config = MagicMock()
+    mock_storage_config.get_store_params.return_value = mock_store_params
+    mock_storage_config.default_adfs_storage = "s3"
+
+    edh_url = f"https://{DATA_EDH_DOMAIN}/copernicus-dem-30m/tile.tif"
+    adfs = [("DEM", "filename", edh_url)]
+
+    result = build_adfs(mock_storage_config, adfs, _make_dpr_process_in(edh_api_key="my-secret-token"))
+
+    path = result[0].path
+    assert isinstance(path, SecretStr)
+    assert "my-secret-token" not in str(path)
+    assert "my-secret-token" not in repr(path)
+
+
+def test_build_adfs_no_edh_key_url_unchanged(mock_store_params):
+    """EDH URL is left unchanged when no API key is provided."""
+    mock_storage_config = MagicMock()
+    mock_storage_config.get_store_params.return_value = mock_store_params
+    mock_storage_config.default_adfs_storage = "s3"
+
+    edh_url = f"https://{DATA_EDH_DOMAIN}/copernicus-dem-30m/tile.tif"
+    adfs = [("DEM", "filename", edh_url)]
+
+    result = build_adfs(mock_storage_config, adfs, _make_dpr_process_in(edh_api_key=None))
+
+    path = result[0].path
+    assert not isinstance(path, SecretStr)
+    assert path == edh_url
+
+
+def test_build_adfs_non_edh_url_not_replaced(mock_store_params):
+    """A non-EDH https URL is not replaced even when an API key is provided."""
+    mock_storage_config = MagicMock()
+    mock_storage_config.get_store_params.return_value = mock_store_params
+    mock_storage_config.default_adfs_storage = "s3"
+
+    other_url = "https://some-other-service.example.com/data/file.tif"
+    adfs = [("ADF1", "filename", other_url)]
+
+    result = build_adfs(mock_storage_config, adfs, _make_dpr_process_in(edh_api_key="my-secret-token"))
+
+    path = result[0].path
+    assert not isinstance(path, SecretStr)
+    assert path == other_url
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Allows to call S1-ARD and read DEM directly from [EarthDataHub](https://earthdatahub.destine.eu/collections/copernicus-dem/datasets/GLO-30) as follows in the payload:

```yaml
  adfs:
  - id: DEM
    path: 'https:/edh:edh_key_xxxxxxxxxxxxxx@api.earthdatahub.destine.eu/copernicus-dem/GLO-30-v0.zarr'
```