### PR TITLE
Retrieve datetimes from adf convertd item_id pattern

### DIFF
--- a/rs_workflows/adf_flow.py
+++ b/rs_workflows/adf_flow.py
@@ -16,6 +16,7 @@
 
 import json
 import os
+import re
 import shutil
 import subprocess  # nosec B404
 import sys
@@ -130,6 +131,34 @@ STAC_DATETIME_PROPERTY_NAMES = {
     "start_datetime",
     "end_datetime",
 }
+
+# Regex to capture start and end datetime tokens from an item_id.
+# Expected pattern: <prefix>_<YYYYMMDDTHHMMSS>_<YYYYMMDDTHHMMSS>_<creation_timestamp>
+_ITEM_ID_DT_RE = re.compile(r"_(\d{8}T\d{6})_(\d{8}T\d{6})_\d{8}T\d{6}$")
+
+
+def extract_datetimes_from_item_id(item_id: str, logger=None) -> tuple[str, str] | None:
+    """Extract start and end datetime ISO strings from an item_id.
+
+    The expected item_id format is:
+        ``<prefix>_<start_YYYYMMDDTHHMMSS>_<end_YYYYMMDDTHHMMSS>_<creation_YYYYMMDDTHHMMSS>``
+
+    Returns a ``(start_iso, end_iso)`` tuple on success, or ``None`` when the
+    pattern does not match.
+    """
+    match = _ITEM_ID_DT_RE.search(item_id)
+    if not match:
+        if logger:
+            logger.warning(f"Could not extract datetimes from item_id: {item_id!r}")
+        return None
+    start_raw, end_raw = match.group(1), match.group(2)
+    start_iso = (
+        datetime.strptime(start_raw, "%Y%m%dT%H%M%S").replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+    end_iso = (
+        datetime.strptime(end_raw, "%Y%m%dT%H%M%S").replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+    return start_iso, end_iso
 
 
 def resolve_collection_name(mappings, product_type: str) -> str | None:
@@ -278,13 +307,25 @@ def create_stac_item_from_zarr(zarr_path: Path, generated_prod_type: str) -> Ite
     logger.info(f"Setting item_id to {item_id}")
 
     # extract start/end datetime for pystac.Item validation.
-    # try to find them in the metadata, but if they are not present, fallback to 'created'
-    # or current time to avoid validation issues. The S00__ADF_GETAS.py script doesn't set but
-    # 'created' field in the metadata, but pystac requires at least one of them to be set, so we need
-    # a fallback mechanism in this case.
+    # try to find them in the metadata, but if they are not present, try to take them from the
+    # item_id string pattern. If still not found, fallback to 'created' or current time
+    # to avoid validation issues. The S00__ADF_GETAS.py script doesn't set but 'created' field
+    # in the metadata, but pystac requires at least one of them to be set, so we need a
+    # fallback mechanism in this case.
+    # This was discussed and agreed with the user:
+    # priority: metadata properties > datetimes embedded in item_id > 'created' > current time.
     fallback_dt_str = stac_props.get("created") or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    start_dt_str = stac_props.get("start_datetime") or fallback_dt_str
-    end_dt_str = stac_props.get("end_datetime") or fallback_dt_str
+    start_dt_str = stac_props.get("start_datetime")
+    end_dt_str = stac_props.get("end_datetime")
+    if not start_dt_str or not end_dt_str:
+        id_datetimes = extract_datetimes_from_item_id(item_id, logger=logger)
+        if id_datetimes:
+            start_dt_str = start_dt_str or id_datetimes[0]
+            end_dt_str = end_dt_str or id_datetimes[1]
+            logger.info(f"Extracted start/end datetimes from item_id: {id_datetimes[0]} / {id_datetimes[1]}")
+        else:
+            start_dt_str = start_dt_str or fallback_dt_str
+            end_dt_str = end_dt_str or fallback_dt_str
 
     start_dt = parse_date(start_dt_str) if start_dt_str else None
     end_dt = parse_date(end_dt_str) if end_dt_str else None

--- a/tests/test_adf_flow.py
+++ b/tests/test_adf_flow.py
@@ -178,6 +178,142 @@ def test_create_stac_item_from_json_falls_back_to_filename(mocker, tmp_path):
     assert item.properties["product:type"] == "ADF_WATER"
 
 
+@pytest.mark.parametrize(
+    "item_id, expected_start, expected_end",
+    [
+        (
+            "S03A_ADF_OLCAL_20211027T000000_20991231T235959_20260612T114433",
+            "2021-10-27T00:00:00Z",
+            "2099-12-31T23:59:59Z",
+        ),
+        (
+            "S00__ADF_ECMWA_20210321T030000_20210321T150000_20260101T000000",
+            "2021-03-21T03:00:00Z",
+            "2021-03-21T15:00:00Z",
+        ),
+    ],
+)
+def test_extract_datetimes_from_item_id_valid(item_id, expected_start, expected_end):
+    """Test extraction of start/end datetimes from a well-formed item_id."""
+    result = adf_flow.extract_datetimes_from_item_id(item_id)
+    assert result is not None
+    start_iso, end_iso = result
+    assert start_iso == expected_start
+    assert end_iso == expected_end
+
+
+@pytest.mark.parametrize(
+    "item_id",
+    [
+        "no-dates-here",
+        # only two timestamps, missing creation
+        "S00__ADF_ECMWA_20210321T030000_20210321T150000",
+        "S00__ADF_ECMWA",
+        "",
+    ],
+)
+def test_extract_datetimes_from_item_id_no_match(item_id):
+    """Test that non-matching item_ids return None."""
+    assert adf_flow.extract_datetimes_from_item_id(item_id) is None
+
+
+def test_create_stac_item_uses_stac_props_over_item_id(mocker, tmp_path):
+    """Test that create_stac_item_from_zarr prefers stac_props datetimes over item_id ones."""
+    mocker.patch("rs_workflows.adf_flow.get_run_logger", return_value=MagicMock())
+    zarr_dir = tmp_path / "test.zarr"
+    zarr_dir.mkdir()
+    zattrs_content = {
+        "id": "S03A_ADF_OLCAL_20211027T000000_20991231T235959_20260612T114433",
+        "properties": {
+            "product:type": "ADF_OLCAL",
+            "created": "2026-06-12T11:44:33Z",
+            # These stac_props should take priority over the item_id datetimes
+            "start_datetime": "2000-01-01T00:00:00Z",
+            "end_datetime": "2000-12-31T23:59:59Z",
+        },
+    }
+    (zarr_dir / ".zattrs").write_text(json.dumps(zattrs_content))
+
+    item = adf_flow.create_stac_item_from_zarr.fn(zarr_dir, "ADF_OLCAL")
+
+    assert item.id == "S03A_ADF_OLCAL_20211027T000000_20991231T235959_20260612T114433"
+    # Datetimes should come from stac_props, not from item_id
+    assert item.common_metadata.start_datetime is not None
+    assert item.common_metadata.end_datetime is not None
+    assert item.common_metadata.start_datetime.year == 2000
+    assert item.common_metadata.start_datetime.month == 1
+    assert item.common_metadata.start_datetime.day == 1
+    assert item.common_metadata.end_datetime.year == 2000
+    assert item.common_metadata.end_datetime.month == 12
+    assert item.common_metadata.end_datetime.day == 31
+
+
+def test_create_stac_item_uses_item_id_when_stac_props_missing(mocker, tmp_path):
+    """Test that item_id datetimes are used when stac_props don't have start/end datetime."""
+    mocker.patch("rs_workflows.adf_flow.get_run_logger", return_value=MagicMock())
+    zarr_dir = tmp_path / "test.zarr"
+    zarr_dir.mkdir()
+    zattrs_content = {
+        "id": "S03A_ADF_OLCAL_20211027T000000_20991231T235959_20260612T114433",
+        "properties": {
+            "product:type": "ADF_OLCAL",
+            "created": "2026-06-12T11:44:33Z",
+            # No start_datetime/end_datetime => should fall back to item_id
+        },
+    }
+    (zarr_dir / ".zattrs").write_text(json.dumps(zattrs_content))
+
+    item = adf_flow.create_stac_item_from_zarr.fn(zarr_dir, "ADF_OLCAL")
+
+    assert item.id == "S03A_ADF_OLCAL_20211027T000000_20991231T235959_20260612T114433"
+    # Datetimes should come from item_id since stac_props don't have them
+    assert item.common_metadata.start_datetime is not None
+    assert item.common_metadata.end_datetime is not None
+    assert item.common_metadata.start_datetime.year == 2021
+    assert item.common_metadata.start_datetime.month == 10
+    assert item.common_metadata.start_datetime.day == 27
+    assert item.common_metadata.end_datetime.year == 2099
+    assert item.common_metadata.end_datetime.month == 12
+    assert item.common_metadata.end_datetime.day == 31
+
+
+def test_create_stac_item_falls_back_to_metadata_when_item_id_has_no_dates(mocker, tmp_path):
+    """Test that metadata properties are used when item_id doesn't match the datetime pattern."""
+    mocker.patch("rs_workflows.adf_flow.get_run_logger", return_value=MagicMock())
+    zarr_dir = tmp_path / "test.zarr"
+    zarr_dir.mkdir()
+    zattrs_content = {
+        "id": "simple-id-no-dates",
+        "properties": {
+            "product:type": "ADF_ECMWA",
+            "start_datetime": "2021-03-21T03:00:00Z",
+            "end_datetime": "2021-03-21T15:00:00Z",
+        },
+    }
+    (zarr_dir / ".zattrs").write_text(json.dumps(zattrs_content))
+
+    item = adf_flow.create_stac_item_from_zarr.fn(zarr_dir, "ADF_ECMWA")
+
+    assert item.id == "simple-id-no-dates"
+    # Datetimes should come from metadata properties since item_id doesn't match
+    assert item.common_metadata.start_datetime is not None
+    assert item.common_metadata.end_datetime is not None
+    assert item.common_metadata.start_datetime.year == 2021
+    assert item.common_metadata.start_datetime.month == 3
+    assert item.common_metadata.start_datetime.day == 21
+    assert item.common_metadata.start_datetime.hour == 3
+    assert item.common_metadata.end_datetime.hour == 15
+
+
+def test_extract_datetimes_from_item_id_logs_warning_on_no_match():
+    """Test that a warning is logged when the item_id pattern doesn't match (make sonarqube happy)"""
+    mock_logger = MagicMock()
+    result = adf_flow.extract_datetimes_from_item_id("no-dates-here", logger=mock_logger)
+    assert result is None
+    mock_logger.warning.assert_called_once()
+    assert "no-dates-here" in mock_logger.warning.call_args[0][0]
+
+
 def test_run_adf_script_returns_generated_zarr(monkeypatch, mocker, tmp_path):
     """Test the conversion script wrapper returns the generated ZARR path."""
     mock_logger = MagicMock()


### PR DESCRIPTION
Implementation for retrieving the start_datetime and end_datetime from the item_id pattern of the generated adf converted