### PR TITLE
Avoid synchronous temp files: stream S3 payloads in memory

### DIFF
--- a/rs_client/ogcapi/dpr_client.py
+++ b/rs_client/ogcapi/dpr_client.py
@@ -16,7 +16,6 @@
 
 import ast
 import os.path as osp
-import tempfile
 from dataclasses import asdict, dataclass
 from enum import Enum
 from pathlib import Path
@@ -167,19 +166,11 @@ class DprClient(OgcApiClient):
                 "s3_report_dir": s3_report_dir,
             } | (extra_data or {})
 
-        # For the mockup processor, pass the payload contents.
-        # Download the payload file into a temp file.
+        # For the mockup processor, read the payload yaml straight from S3.
         else:
-            with tempfile.NamedTemporaryFile() as temp:
-                prefect_utils.s3_download_file(  # type: ignore
-                    osp.join(s3_config_dir, payload_subpath),
-                    temp.name,
-                    _sync=True,  # type: ignore
-                )
-
-                # Read it as a yaml file
-                with open(temp.name, encoding="utf-8") as opened:
-                    data = yaml.safe_load(opened)
+            data = yaml.safe_load(
+                prefect_utils.s3_read_bytes(osp.join(s3_config_dir, payload_subpath), _sync=True),  # type: ignore
+            )
 
             # Add extra info
             data.update({"use_mockup": use_mockup})
@@ -317,10 +308,5 @@ class DprClient(OgcApiClient):
             # yaml to str conversion
             contents = yaml.dump(payload, default_flow_style=False, sort_keys=False)
 
-        # Write the modified contents to a temp file
-        with tempfile.NamedTemporaryFile() as tmp:
-            tmp.write(contents.encode("utf-8"))
-            tmp.flush()
-
-            # Upload the temp file to the s3 bucket
-            return await prefect_utils.s3_upload_file(tmp.name, str(s3_path))
+        # Upload the modified contents to the s3 bucket.
+        return await prefect_utils.s3_upload_bytes(contents.encode("utf-8"), str(s3_path))

--- a/rs_common/prefect_utils.py
+++ b/rs_common/prefect_utils.py
@@ -19,11 +19,11 @@ WARNING: AFTER EACH MODIFICATION, RESTART THE JUPYTER NOTEBOOK KERNEL !
 
 import asyncio
 import getpass
+import io
 import json
 import os
 import re
 import socket
-import tempfile
 from collections.abc import Callable
 from pathlib import Path
 from threading import Lock
@@ -102,6 +102,12 @@ def format_env_user(block_name: str, any_owner_id: str):
     return re.sub("[^a-zA-Z0-9]", "-", name)  # replace special characters by dash
 
 
+def _append_apikey_to_env(apikey: str) -> None:
+    """Append the API key to the user's ~/.env file (blocking I/O, run off the event loop)."""
+    with open(os.path.expanduser("~/.env"), "a", encoding="utf-8") as env_file:
+        env_file.write(f"\nRSPY_APIKEY={apikey}\n")
+
+
 @sync_compatible
 async def read_apikey(optional: bool = False, save_to_env: bool = True) -> None:
     """
@@ -132,9 +138,8 @@ async def read_apikey(optional: bool = False, save_to_env: bool = True) -> None:
         # Append it to the ~/.env file, if requested.
         # Don't overwrite the full ~/.env file because it can contain other user info.
         if save_to_env:
-            with open(os.path.expanduser("~/.env"), "a", encoding="utf-8") as env_file:
-                env_file.write(f"\nRSPY_APIKEY={apikey}\n")
-                logger.debug("API key saved to '~/.env'")
+            await asyncio.to_thread(_append_apikey_to_env, apikey)
+            logger.debug("API key saved to '~/.env'")
 
 
 @sync_compatible
@@ -495,22 +500,27 @@ async def s3_upload_file(
     return await s3_bucket.aupload_from_path(from_path, to_path, **upload_kwargs)
 
 
+async def s3_upload_bytes(data: bytes, s3_path: str, **upload_kwargs: dict[str, Any]) -> str:
+    """Upload in-memory bytes straight to the S3 bucket, without writing a temporary file."""
+    s3_bucket, to_path = get_s3_bucket(s3_path)
+    return await s3_bucket.aupload_from_file_object(io.BytesIO(data), to_path, **upload_kwargs)
+
+
+@sync_compatible
+async def s3_read_bytes(s3_path: str) -> bytes:
+    """Read an object's bytes straight from the S3 bucket, without a temporary file."""
+    s3_bucket, from_path = get_s3_bucket(s3_path)
+    return await s3_bucket.aread_path(from_path)
+
+
 @sync_compatible
 async def s3_upload_empty_file(
     s3_path: str,
     **upload_kwargs: dict[str, Any],
 ) -> str:
     """Upload an empty temp file to the S3 bucket."""
-
-    # Create a tmp file
-    with tempfile.NamedTemporaryFile() as tmp:
-
-        # Add contents to the file or boto3 has a strange behavior after uploading an empty file
-        tmp.write(b"empty")
-        tmp.flush()
-
-        # Upload the file
-        return await s3_upload_file(tmp.name, s3_path, **upload_kwargs)
+    # Add contents to the file or boto3 has a strange behavior after uploading an empty file
+    return await s3_upload_bytes(b"empty", s3_path, **upload_kwargs)
 
 
 @sync_compatible

--- a/rs_workflows/dpr_flow.py
+++ b/rs_workflows/dpr_flow.py
@@ -24,7 +24,6 @@ from datetime import timedelta
 # import datetime
 from os import path as osp
 from pathlib import Path
-from typing import Any
 
 import anyio
 from prefect import get_run_logger, task
@@ -95,27 +94,8 @@ def extract_products_and_zattrs(files: list[str], base_path: str):
 
 
 def read_zattrs_sync(path: str):
-    """
-    Download `.zattrs` file synchronously using prefect_utils.s3_download_file
-    and return parsed JSON dicts in memory.
-    """
-    with tempfile.NamedTemporaryFile() as temp:
-        s3_download_file_sync(path, str(temp.name), _sync=True)
-        with open(temp.name, encoding="utf-8") as f:
-            return json.load(f)
-
-
-def s3_download_file_sync(
-    s3_path: str,
-    to_path: str | Path,
-    **download_kwargs: Any,
-) -> str | Path:
-    """
-    Download a file from S3 synchronously.
-    """
-    s3_bucket, from_path = prefect_utils.get_s3_bucket(s3_path)
-    s3_bucket.download_object_to_path(from_path, str(to_path), **download_kwargs)
-    return to_path
+    """Read a `.zattrs` file from S3 synchronously and return the parsed JSON, in memory."""
+    return json.loads(prefect_utils.s3_read_bytes(path, _sync=True))  # type: ignore
 
 
 def create_stac_item(

--- a/rs_workflows/on_demand_processing.py
+++ b/rs_workflows/on_demand_processing.py
@@ -16,15 +16,12 @@
 
 # pylint: disable=W0101  # ignore 'unreachable code' (temporar)
 
-import datetime
 import json
 import os
 import re
-import tempfile as std_tempfile
 from copy import deepcopy
 from typing import Any
 
-import anyio
 import yaml
 from prefect import flow, get_run_logger, task
 from prefect.artifacts import acreate_markdown_artifact
@@ -508,18 +505,9 @@ async def dpr_processing(
         # the payload file to upload to S3. here, the secrets are revealed
         generated_payload_res_with_secrets = generated_payload_res.dump(reveal_secrets=True)
         yaml_str = yaml.dump(generated_payload_res_with_secrets, default_flow_style=False, sort_keys=False)
-        # upload the config payload file to S3
-        tmp_dir = std_tempfile.gettempdir()
-        tmp_file_path = os.path.join(tmp_dir, f"dpr_payload_{datetime.datetime.now().timestamp()}.yaml")
-        async with await anyio.open_file(tmp_file_path, "w", encoding="utf-8") as tmp_file:
-            await tmp_file.write(yaml_str)
-            # flush to be extra-safe
-            await tmp_file.flush()
+        # upload the config payload contents straight to S3, without a temporary file
         logger.debug(f"Writing the payload to file :\n {dpr_input.s3_payload_file}")
-        await prefect_utils.s3_upload_file(tmp_file_path, dpr_input.s3_payload_file)
-
-        # clean up the temp payload file
-        await anyio.Path(tmp_file_path).unlink()
+        await prefect_utils.s3_upload_bytes(yaml_str.encode("utf-8"), dpr_input.s3_payload_file)
 
         # Run the DPR processor
         processed_items = run_processor.submit(

--- a/tests/test_dpr.py
+++ b/tests/test_dpr.py
@@ -18,7 +18,6 @@ import getpass
 import tempfile
 from unittest.mock import AsyncMock
 
-import anyio
 import pytest
 import responses
 from starlette import status
@@ -65,15 +64,11 @@ def test_dpr_client(mocker, dpr_client: DprClient, process: str, ogcapi_response
         status=status.HTTP_200_OK,
     )
 
-    def mock_download(_, to_path, **__):
-        """
-        Mock downloading of the payload file (for the mockup process).
-        Create an empty yaml file in the target path..
-        """
-        with open(to_path, "w", encoding="utf-8") as opened:
-            opened.write("empty:")
-
-    mocker.patch("rs_client.ogcapi.dpr_client.prefect_utils.s3_download_file", new=mock_download)
+    # Mock reading of the payload file (for the mockup process): return empty yaml bytes
+    mocker.patch(
+        "rs_client.ogcapi.dpr_client.prefect_utils.s3_read_bytes",
+        return_value=b"empty:",
+    )
 
     # Run the DPR processing
     assert dpr_client.run_process(process, CLUSTER_INFO, "", "", "", {}) == ogcapi_response_sample
@@ -161,15 +156,14 @@ I/O:
         new_callable=AsyncMock,
     )
 
-    async def mock_upload(from_path, _, **__):
+    async def mock_upload(data, _s3_path, **__):
         """
-        Mock uploading of the payload file.
-        Return the uploaded file contents.
+        Mock uploading of the payload contents.
+        Return the uploaded contents as text.
         """
-        async with await anyio.open_file(from_path, encoding="utf-8") as opened:
-            return await opened.read()
+        return data.decode("utf-8")
 
-    mocker.patch("rs_client.ogcapi.dpr_client.prefect_utils.s3_upload_file", new=mock_upload)
+    mocker.patch("rs_client.ogcapi.dpr_client.prefect_utils.s3_upload_bytes", new=mock_upload)
 
     # Write dummy payload file
     with tempfile.NamedTemporaryFile() as tmp:

--- a/tests/test_dpr_flow_helper.py
+++ b/tests/test_dpr_flow_helper.py
@@ -16,7 +16,6 @@
 import datetime
 import json
 import typing
-from pathlib import Path
 
 import pytest
 
@@ -29,7 +28,6 @@ from rs_workflows.dpr_flow import (
     extract_products_and_zattrs,
     read_zattrs_sync,
     run_processor,
-    s3_download_file_sync,
     s3_list,
     update_eopf_assets,
 )
@@ -85,11 +83,10 @@ def test_s3_list_returns_full_s3_paths(mocker):
     mock_objects.filter.assert_called_once_with(Prefix="some/prefix/")
 
 
-def test_read_zattrs_sync_downloads_and_parses_json(mocker):
+def test_read_zattrs_sync_reads_and_parses_json(mocker):
     """
-    Verify that read_zattrs_sync correctly downloads each .zattrs file from S3,
-    reads its JSON content, and returns a list of dictionaries containing both
-    the original path and the parsed data.
+    Verify that read_zattrs_sync reads the .zattrs bytes straight from S3 (no temp file)
+    and returns the parsed JSON.
     """
     zattrs_path = "s3://my-bucket/product_a/.zattrs"
 
@@ -98,21 +95,15 @@ def test_read_zattrs_sync_downloads_and_parses_json(mocker):
         "answer": 42,
     }
 
-    def fake_s3_download(src, dest, _sync):  # pylint: disable=unused-argument
-        with open(dest, "w", encoding="utf-8") as f:
-            json.dump(fake_json_data, f)
-
-    mock_download = mocker.patch(
-        "rs_workflows.dpr_flow.s3_download_file_sync",
-        side_effect=fake_s3_download,
+    mock_read = mocker.patch(
+        "rs_workflows.dpr_flow.prefect_utils.s3_read_bytes",
+        return_value=json.dumps(fake_json_data).encode("utf-8"),
     )
 
     result = read_zattrs_sync(zattrs_path)
 
     assert result == fake_json_data
-
-    assert mock_download.call_count == 1
-    mock_download.assert_any_call(zattrs_path, mocker.ANY, _sync=True)
+    mock_read.assert_called_once_with(zattrs_path, _sync=True)
 
 
 def test_extract_products_and_zattrs():
@@ -197,40 +188,6 @@ def test_extract_products_and_zattrs_no_matches():
 
     result = extract_products_and_zattrs(files, base_path)
     assert not result
-
-
-def test_s3_download_file_sync_downloads_and_returns_path(mocker):
-    """
-    Verify that s3_download_file_sync calls the underlying S3 bucket's
-    download_object_to_path with the correct arguments and returns the
-    destination path unchanged.
-    """
-    s3_path = "s3://my-bucket/some/file.txt"
-    to_path = Path("/tmp/file.txt")
-
-    mock_s3_bucket = mocker.Mock()
-    mock_from_path = "some/file.txt"
-
-    mocker.patch(
-        "rs_workflows.dpr_flow.prefect_utils.get_s3_bucket",
-        return_value=(mock_s3_bucket, mock_from_path),
-    )
-
-    result = s3_download_file_sync(
-        s3_path,
-        to_path,
-        _sync=True,
-        extra_arg="value",
-    )
-
-    mock_s3_bucket.download_object_to_path.assert_called_once_with(
-        mock_from_path,
-        str(to_path),
-        _sync=True,
-        extra_arg="value",
-    )
-
-    assert result == to_path
 
 
 def test_create_stac_items_builds_items_with_assets_and_eopf_metadata(mocker):

--- a/tests/test_prefect_utils.py
+++ b/tests/test_prefect_utils.py
@@ -248,7 +248,8 @@ async def test_bucket_functions(monkeypatch, mocker):
     await prefect_utils.s3_upload_file("from_path", "s3_path")
     my_spy.assert_called_once()
 
-    my_spy.reset_mock()
+    # s3_upload_empty_file uploads in-memory bytes (no temp file) via aupload_from_file_object
+    mocker.patch.object(S3Bucket, "aupload_from_file_object", my_spy := AsyncMock())
     await prefect_utils.s3_upload_empty_file("s3_path")
     my_spy.assert_called_once()
 
@@ -273,3 +274,36 @@ async def test_bucket_functions(monkeypatch, mocker):
     # Call the function
     prefect_utils.s3_delete("s3_prefix")
     spy_delete_objects.assert_called_once()
+
+
+async def test_s3_upload_bytes_uploads_in_memory(mocker):
+    """s3_upload_bytes streams in-memory bytes straight to S3, without touching the disk."""
+    captured: dict = {}
+
+    async def fake_upload(from_file_object, to_path, **_kwargs):
+        captured["to_path"] = to_path
+        captured["contents"] = from_file_object.read()
+        return "uploaded"
+
+    mock_bucket = mocker.Mock()
+    mock_bucket.aupload_from_file_object = AsyncMock(side_effect=fake_upload)
+    mocker.patch.object(prefect_utils, "get_s3_bucket", return_value=(mock_bucket, "key"))
+
+    result = await prefect_utils.s3_upload_bytes(b"hello world", "s3://bucket/key")
+
+    assert result == "uploaded"
+    assert captured["to_path"] == "key"
+    assert captured["contents"] == b"hello world"
+    mock_bucket.aupload_from_file_object.assert_awaited_once()
+
+
+async def test_s3_read_bytes_reads_in_memory(mocker):
+    """s3_read_bytes reads an object's bytes straight from S3, without touching the disk."""
+    mock_bucket = mocker.Mock()
+    mock_bucket.aread_path = AsyncMock(return_value=b"file contents")
+    mocker.patch.object(prefect_utils, "get_s3_bucket", return_value=(mock_bucket, "key"))
+
+    result = await prefect_utils.s3_read_bytes("s3://bucket/key")
+
+    assert result == b"file contents"
+    mock_bucket.aread_path.assert_awaited_once_with("key")

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -148,7 +148,7 @@ async def test_dpr_processing(
 
     # Spy on function calls
     spy_add_item = mocker.spy(catalog_client.CatalogClient, "add_item")
-    spy_s3_upload_file = mocker.spy(prefect_utils, "s3_upload_file")
+    spy_s3_upload_bytes = mocker.spy(prefect_utils, "s3_upload_bytes")
     spy_s3_delete = mocker.spy(prefect_utils, "s3_delete")
     monkeypatch.setenv("RSPY_HOST_OSAM", "https://dummy-osam")
     mocker.patch(
@@ -241,11 +241,11 @@ async def test_dpr_processing(
 
     assert result_items == expected_items
 
-    # --- verify s3_upload_file was called with the expected destination (second arg) ---
-    upload_calls = spy_s3_upload_file.call_args_list
+    # --- verify the payload was uploaded in memory to the expected destination ---
+    upload_calls = spy_s3_upload_bytes.call_args_list
     assert len(upload_calls) == 1
     args = upload_calls[0].args
-    assert isinstance(args[0], (str, Path))  # temp file path
+    assert isinstance(args[0], bytes)  # in-memory payload contents
     assert args[1] == dpr_input.s3_payload_file  # destination S3 path
 
     # --- verify s3_delete was called with the payload file ---


### PR DESCRIPTION
Replace the synchronous file I/O flagged by SonarQube in async functions, and more generally drop temporary files when a single object is read from / written to S3 — uploading/reading the bytes in memory is faster and simpler.

prefect_utils gains two helpers:
- s3_upload_bytes(): uploads in-memory bytes via S3Bucket.aupload_from_file_object (used by s3_upload_empty_file and the callers below);
- s3_read_bytes(): reads an object's bytes via S3Bucket.aread_path.

Callers simplified (no more download/write-to-temp-then-read):
- dpr_client.update_configuration / mockup payload: upload and read straight from S3;
- dpr_flow.read_zattrs_sync: read .zattrs in memory (dead s3_download_file_sync removed);
- on_demand_processing: upload the generated payload in memory;
- read_apikey: the ~/.env append now runs off the event loop via asyncio.to_thread.

Temp directories that back archive extraction or subprocess conversion (adf_flow, rs_workflows/utils, dpr_flow report download) are kept as-is.

Tests updated/added accordingly (s3_upload_bytes, s3_read_bytes, read_zattrs_sync).