### PR TITLE
Add unit tests for the rs_workflows/on_demand flows

### DIFF
--- a/tests/test_on_demand_adf.py
+++ b/tests/test_on_demand_adf.py
@@ -1,0 +1,276 @@
+# Copyright 2023-2026 Airbus, CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for rs_workflows.on_demand.adf.convert_adf_set."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rs_workflows.flow_utils import AuxiliaryProductMapping, FlowEnvArgs
+from rs_workflows.on_demand.adf import config as adf_config
+from rs_workflows.on_demand.adf import convert_adf_set as cas
+
+AUX_MAPPING = [AuxiliaryProductMapping(product_type="AX", collection_name="AUX")]
+
+
+def _logger(mocker):
+    mocker.patch.object(cas, "get_run_logger", return_value=MagicMock())
+
+
+def test_config_package_exposes_version():
+    """The adf config package is importable and exposes a version."""
+    assert isinstance(adf_config.__version__, str)
+
+
+# --------------------------------------------------------------------------- #
+# compute_cql2
+# --------------------------------------------------------------------------- #
+def test_compute_cql2_returns_structure_and_substitutes_dt(mocker):
+    """compute_cql2 loads the config and substitutes the dTa/dTb values."""
+    _logger(mocker)
+    result = cas.compute_cql2("ValIntersect", 1, 2, "S1A")
+    assert set(result) == {"filter", "sortby", "limit"}
+    dumped = json.dumps(result)
+    assert "{dTa}" not in dumped
+    assert "{dTb}" not in dumped
+    # placeholders resolved later in the pipeline are left untouched here
+    assert "{product_type}" in dumped
+
+
+def test_compute_cql2_unknown_query_raises(mocker):
+    """An unknown query name cannot be found in the configuration."""
+    _logger(mocker)
+    with pytest.raises(StopIteration):
+        cas.compute_cql2("does-not-exist", 0, 0, None)
+
+
+# --------------------------------------------------------------------------- #
+# convert_adf_group
+# --------------------------------------------------------------------------- #
+def _patch_group(mocker, settings):
+    _logger(mocker)
+    mocker.patch.object(cas.Variable, "get", new=AsyncMock(return_value=settings))
+    sched = mocker.patch.object(cas, "schedule_adf_conversion")
+    sched.with_options.return_value = AsyncMock()
+    past = mocker.patch.object(cas, "past_adf_conversion")
+    past.with_options.return_value = AsyncMock()
+    return sched, past
+
+
+async def test_convert_adf_group_rejects_bad_chronology(mocker):
+    """period_start must be strictly before period_end."""
+    _logger(mocker)
+    now = datetime.now(timezone.utc)
+    with pytest.raises(ValueError, match="before period_end"):
+        await cas.convert_adf_group.fn(now, now - timedelta(days=1), "grp")
+
+
+async def test_convert_adf_group_missing_variable(mocker):
+    """A missing Prefect variable raises FileExistsError."""
+    _logger(mocker)
+    mocker.patch.object(cas.Variable, "get", new=AsyncMock(return_value=None))
+    now = datetime.now(timezone.utc)
+    with pytest.raises(FileExistsError, match="does not exist"):
+        await cas.convert_adf_group.fn(now - timedelta(days=1), now + timedelta(days=1), "grp")
+
+
+async def test_convert_adf_group_invalid_variable_format(mocker):
+    """A non-dict Prefect variable payload raises ValueError."""
+    _logger(mocker)
+    mocker.patch.object(cas.Variable, "get", new=AsyncMock(return_value="not-a-dict"))
+    now = datetime.now(timezone.utc)
+    with pytest.raises(ValueError, match="invalid format"):
+        await cas.convert_adf_group.fn(now - timedelta(days=1), now + timedelta(days=1), "grp")
+
+
+async def test_convert_adf_group_past_only(mocker):
+    """A fully-past period runs the conversion for each aux and schedules nothing."""
+    aux = [
+        {"product_type": "ADF_A", "cql2_query_name": "ValIntersect", "period_in_hours": 6},
+        {"product_type": "ADF_B", "cql2_query_name": "ValIntersect", "period_in_hours": 0},
+    ]
+    settings = {"satellite": "S1A", "aux-to-be-generated": aux, "auxiliary-product-to-collection-identifier": []}
+    sched, past = _patch_group(mocker, settings)
+    now = datetime.now(timezone.utc)
+
+    await cas.convert_adf_group.fn(now - timedelta(days=2), now - timedelta(days=1), "grp")
+
+    assert past.with_options.call_count == 2
+    sched.with_options.assert_not_called()
+
+
+async def test_convert_adf_group_future_only(mocker):
+    """A fully-future period schedules a conversion for each aux and runs nothing now."""
+    aux = [{"product_type": "ADF_A", "cql2_query_name": "ValIntersect", "period_in_hours": 6}]
+    settings = {"satellite": "S1A", "aux-to-be-generated": aux, "auxiliary-product-to-collection-identifier": []}
+    sched, past = _patch_group(mocker, settings)
+    now = datetime.now(timezone.utc)
+
+    await cas.convert_adf_group.fn(now + timedelta(days=1), now + timedelta(days=2), "grp")
+
+    assert sched.with_options.return_value.await_count == 1
+    past.with_options.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# past_adf_conversion
+# --------------------------------------------------------------------------- #
+async def test_past_adf_conversion_single_run(mocker):
+    """period_in_hours == 0 runs the conversion once over the whole period."""
+    _logger(mocker)
+    mocker.patch.object(cas, "compute_cql2", return_value={})
+    conv = mocker.patch.object(cas, "adf_conversion_task")
+    conv.with_options.return_value = AsyncMock()
+    now = datetime.now(timezone.utc)
+
+    await cas.past_adf_conversion.fn(
+        "owner",
+        "ADF_A",
+        "ValIntersect",
+        0,
+        0,
+        0,
+        now - timedelta(hours=2),
+        now,
+        AUX_MAPPING,
+        "S1A",
+    )
+
+    conv.with_options.return_value.assert_awaited_once()
+
+
+async def test_past_adf_conversion_splits_period(mocker):
+    """A non-zero period splits the range into sub-periods (12h / 6h -> 3 runs)."""
+    _logger(mocker)
+    mocker.patch.object(cas, "compute_cql2", return_value={})
+    conv = mocker.patch.object(cas, "adf_conversion_task")
+    conv.with_options.return_value = AsyncMock()
+    start = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    await cas.past_adf_conversion.fn(
+        "owner",
+        "ADF_A",
+        "ValIntersect",
+        0,
+        0,
+        6,
+        start,
+        start + timedelta(hours=12),
+        AUX_MAPPING,
+        "S",
+    )
+
+    assert conv.with_options.return_value.await_count == 3
+
+
+# --------------------------------------------------------------------------- #
+# schedule_adf_conversion
+# --------------------------------------------------------------------------- #
+async def test_schedule_adf_conversion_single_rule(mocker):
+    """A zero period produces a one-shot HOURLY;UNTIL rule."""
+    _logger(mocker)
+    mocker.patch.object(cas, "compute_cql2", return_value={})
+    flow_mock = mocker.patch.object(cas, "schedule_conversion_flow", new=AsyncMock())
+    start = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    await cas.schedule_adf_conversion.fn(
+        "owner",
+        "ADF_A",
+        "ValIntersect",
+        0,
+        0,
+        0,
+        start,
+        start + timedelta(hours=5),
+        [],
+        "S",
+    )
+
+    flow_mock.assert_awaited_once()
+    rule = flow_mock.call_args.args[1]
+    assert "FREQ=HOURLY;UNTIL=" in rule
+    assert "INTERVAL" not in rule
+
+
+async def test_schedule_adf_conversion_interval_rule(mocker):
+    """A non-zero period produces a recurring HOURLY;INTERVAL rule."""
+    _logger(mocker)
+    mocker.patch.object(cas, "compute_cql2", return_value={})
+    flow_mock = mocker.patch.object(cas, "schedule_conversion_flow", new=AsyncMock())
+    start = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    await cas.schedule_adf_conversion.fn(
+        "owner",
+        "ADF_A",
+        "ValIntersect",
+        0,
+        0,
+        6,
+        start,
+        start + timedelta(hours=12),
+        [],
+        "S",
+    )
+
+    rule = flow_mock.call_args.args[1]
+    assert "INTERVAL=6" in rule
+
+
+# --------------------------------------------------------------------------- #
+# adf_conversion_scheduled
+# --------------------------------------------------------------------------- #
+async def test_adf_conversion_scheduled_runs_conversion(mocker):
+    """The scheduled flow decodes the period and runs the conversion for the window."""
+    _logger(mocker)
+    flow_run_mock = mocker.patch.object(cas, "flow_run")
+    flow_run_mock.scheduled_start_time = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    conv = mocker.patch.object(cas, "adf_conversion_task")
+    conv.with_options.return_value = AsyncMock()
+
+    await cas.adf_conversion_scheduled.fn(FlowEnvArgs(owner_id="owner"), "ADF_A", {}, "3600", AUX_MAPPING)
+
+    conv.with_options.return_value.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+# schedule_conversion_flow
+# --------------------------------------------------------------------------- #
+async def test_schedule_conversion_flow_deploys(mocker):
+    """schedule_conversion_flow reads the deployment and deploys a scheduled flow."""
+    _logger(mocker)
+    mocker.patch.object(cas, "runtime", MagicMock())
+    mocker.patch.object(cas, "GitRepository", return_value=MagicMock())
+
+    deployment = MagicMock()
+    deployment.work_pool_name = "pool"
+    deployment.pull_steps = [{"git_clone": {"repository": "https://example.com/repo.git", "branch": "main"}}]
+    client = MagicMock()
+    client.read_deployment = AsyncMock(return_value=deployment)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=client)
+    ctx.__aexit__ = AsyncMock(return_value=None)
+    mocker.patch.object(cas, "get_client", return_value=ctx)
+
+    flow_obj = MagicMock()
+    flow_obj.deploy = AsyncMock()
+    mocker.patch.object(cas.flow, "from_source", new=AsyncMock(return_value=flow_obj))
+
+    await cas.schedule_conversion_flow("owner", "RULE", {}, "ADF_A", timedelta(hours=1), [])
+
+    flow_obj.deploy.assert_awaited_once()
+    assert flow_obj.deploy.call_args.kwargs["work_pool_name"] == "pool"
+    assert flow_obj.deploy.call_args.kwargs["rrule"] == "RULE"

--- a/tests/test_on_demand_l0.py
+++ b/tests/test_on_demand_l0.py
@@ -1,0 +1,237 @@
+# Copyright 2023-2026 Airbus, CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the on_demand Level-0 flows (common.l0, common.l0_last_steps, sentinel1/3)."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rs_workflows.flow_utils import FlowInputProduct
+from rs_workflows.on_demand.common import l0, l0_last_steps
+from rs_workflows.on_demand.sentinel1 import s1_l0
+from rs_workflows.on_demand.sentinel3 import s3_l0
+
+
+def _resolved_params():
+    """A resolved Level0FlowParams-like object with the attributes used by the flows."""
+    return MagicMock(
+        owner_identifier="owner",
+        dask_cluster_label="cluster",
+        session_collection="s01-cadip-session",
+        cadip_collections=["s1_sgs"],
+        processor_name="proc",
+        processor_version="1.0",
+        pipeline=None,
+        unit=None,
+        priority=None,
+        processing_mode=[],
+        workflow=None,
+        generated_product_to_collection_identifier=None,
+        auxiliary_product_to_collection_identifier=None,
+        logging_level="INFO",
+    )
+
+
+def _flow_params():
+    """A flow_params object whose resolve() returns the resolved params."""
+    params = MagicMock()
+    params.resolve = AsyncMock(return_value=_resolved_params())
+    return params
+
+
+# --------------------------------------------------------------------------- #
+# process_l0
+# --------------------------------------------------------------------------- #
+def _patch_l0(
+    mocker,
+    *,
+    dask_running=True,
+    item=None,
+    station=None,
+    staged=True,
+    evicted=(False, None),
+    published=True,
+):
+    mocker.patch.object(l0, "get_run_logger", return_value=MagicMock())
+    flow_env = MagicMock()
+    flow_env.start_span.return_value.__enter__.return_value = MagicMock()
+    mocker.patch.object(l0, "FlowEnv", return_value=flow_env)
+    mocker.patch.object(l0, "is_dask_cluster_running", new=AsyncMock(return_value=dask_running))
+    mocker.patch.object(l0, "get_single_catalog_item", new=AsyncMock(return_value=item))
+    mocker.patch.object(l0, "is_evicted", return_value=evicted)
+    mocker.patch.object(l0, "is_published", return_value=published)
+    mocker.patch.object(l0, "get_cadip_station", new=AsyncMock(return_value=station))
+    stage_mock = mocker.patch.object(l0, "stage_session_common", new=AsyncMock(return_value=staged))
+    s1_mock = mocker.patch.object(l0, "process_s1l0_task", new=AsyncMock())
+    s3_mock = mocker.patch.object(l0, "process_s3l0_task", new=AsyncMock())
+    return {"stage": stage_mock, "s1": s1_mock, "s3": s3_mock}
+
+
+async def test_process_l0_rejects_bad_session_name(mocker):
+    """An invalid session name raises ValueError before any processing."""
+    mocker.patch.object(l0, "get_run_logger", return_value=MagicMock())
+    with pytest.raises(ValueError, match="Invalid session name"):
+        await l0.process_l0.fn("INVALID", _flow_params())
+
+
+async def test_process_l0_raises_when_dask_cluster_not_ready(mocker):
+    """An unknown/not-ready dask cluster raises ValueError."""
+    _patch_l0(mocker, dask_running=False)
+    with pytest.raises(ValueError, match="unknown or not ready"):
+        await l0.process_l0.fn("S1A_20230101T000000", _flow_params())
+
+
+async def test_process_l0_raises_when_session_evicted(mocker):
+    """A found but evicted session raises ValueError."""
+    _patch_l0(mocker, item=MagicMock(), evicted=(True, "2020-01-01"))
+    with pytest.raises(ValueError, match="evicted"):
+        await l0.process_l0.fn("S1A_20230101T000000", _flow_params())
+
+
+async def test_process_l0_raises_when_session_not_published(mocker):
+    """A found session that is not published yet raises ValueError."""
+    _patch_l0(mocker, item=MagicMock(), evicted=(False, None), published=False)
+    with pytest.raises(ValueError, match="not been publised"):
+        await l0.process_l0.fn("S1A_20230101T000000", _flow_params())
+
+
+async def test_process_l0_dispatches_s1_when_found_in_catalog(mocker):
+    """A published S1 session in the catalog is dispatched to the S1 processor."""
+    mocks = _patch_l0(mocker, item=MagicMock(), published=True)
+    await l0.process_l0.fn("S1A_20230101T000000", _flow_params())
+    mocks["s1"].assert_awaited_once()
+    mocks["s3"].assert_not_awaited()
+
+
+async def test_process_l0_stages_then_dispatches_s3(mocker):
+    """An S3 session absent from the catalog is staged then dispatched to the S3 processor."""
+    mocks = _patch_l0(mocker, item=None, station="s3_sgs", staged=True)
+    await l0.process_l0.fn("S3A_20230101T000000", _flow_params())
+    mocks["stage"].assert_awaited_once()
+    mocks["s3"].assert_awaited_once()
+    mocks["s1"].assert_not_awaited()
+
+
+async def test_process_l0_no_dispatch_when_station_not_found(mocker):
+    """When the session is neither cataloged nor stageable, no processor runs."""
+    mocks = _patch_l0(mocker, item=None, station=None)
+    await l0.process_l0.fn("S1A_20230101T000000", _flow_params())
+    mocks["stage"].assert_not_awaited()
+    mocks["s1"].assert_not_awaited()
+    mocks["s3"].assert_not_awaited()
+
+
+async def test_process_l0_uses_default_params_when_none(mocker):
+    """When no flow_params is given, a default Level0FlowParams is built and resolved."""
+    mocks = _patch_l0(mocker, item=MagicMock(), published=True)
+    mocker.patch.object(l0, "Level0FlowParams", return_value=_flow_params())
+    await l0.process_l0.fn("S1A_20230101T000000", None)
+    mocks["s1"].assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+# process_l0_last_steps
+# --------------------------------------------------------------------------- #
+def _patch_last_steps(mocker, item):
+    mocker.patch.object(l0_last_steps, "get_run_logger", return_value=MagicMock())
+    flow_env = MagicMock()
+    flow_env.start_span.return_value.__enter__.return_value = MagicMock()
+    mocker.patch.object(l0_last_steps, "FlowEnv", return_value=flow_env)
+    mocker.patch.object(l0_last_steps, "get_single_catalog_item", new=AsyncMock(return_value=item))
+    return mocker.patch.object(l0_last_steps, "call_dpr_flow", new=AsyncMock())
+
+
+async def test_process_l0_last_steps_returns_early_without_item(mocker):
+    """When the session is not in the catalog, no DPR flow is triggered."""
+    dpr_mock = _patch_last_steps(mocker, item=None)
+    await l0_last_steps.process_l0_last_steps("1", "S1A_x", _flow_params(), [], verbose=False)
+    dpr_mock.assert_not_awaited()
+
+
+async def test_process_l0_last_steps_raises_on_missing_published(mocker):
+    """A missing/invalid 'published' property raises ValueError."""
+    item = MagicMock()
+    item.properties = {}
+    _patch_last_steps(mocker, item=item)
+    with pytest.raises(ValueError, match="published"):
+        await l0_last_steps.process_l0_last_steps("1", "S1A_x", _flow_params(), [], verbose=False)
+
+
+async def test_process_l0_last_steps_calls_dpr_flow(mocker):
+    """A published session triggers call_dpr_flow with the computed satellite and datetimes."""
+    item = MagicMock()
+    item.properties = {"published": "2023-01-01T00:00:00"}
+    dpr_mock = _patch_last_steps(mocker, item=item)
+    products = [FlowInputProduct(name="S1CADUS", item_id="S1A_session", collection_name="coll")]
+
+    await l0_last_steps.process_l0_last_steps("1", "S1A_session", _flow_params(), products, verbose=True)
+
+    dpr_mock.assert_awaited_once()
+    kwargs = dpr_mock.call_args.kwargs
+    assert kwargs["input_products"] == products
+    assert kwargs["external_variables"]["satellite"] == "sentinel-1a"
+    assert kwargs["external_variables"]["start_datetime"] == datetime.fromisoformat("2023-01-01T00:00:00")
+    assert kwargs["external_variables"]["end_datetime"] == datetime.fromisoformat("2023-01-01T00:00:00")
+
+
+# --------------------------------------------------------------------------- #
+# sentinel1 / sentinel3 entry points
+# --------------------------------------------------------------------------- #
+async def test_process_s1l0_builds_s1_input_and_delegates(mocker):
+    """process_s1l0 builds the S1CADUS input product and delegates to the common last steps."""
+    last_steps = mocker.patch.object(s1_l0, "process_l0_last_steps", new=AsyncMock())
+    flow_params = MagicMock(session_collection="s01-cadip-session")
+
+    await s1_l0.process_s1l0.fn("S1A_session", flow_params, verbose=False)
+
+    last_steps.assert_awaited_once()
+    kwargs = last_steps.call_args.kwargs
+    assert kwargs["mission"] == "1"
+    assert kwargs["session"] == "S1A_session"
+    products = kwargs["input_products"]
+    assert len(products) == 1
+    assert products[0].name == "S1CADUS"
+    assert products[0].item_id == "S1A_session"
+    assert products[0].collection_name == "s01-cadip-session"
+
+
+async def test_process_s3l0_builds_s3_input_and_delegates(mocker):
+    """process_s3l0 builds the S3ACADUS input product and delegates to the common last steps."""
+    last_steps = mocker.patch.object(s3_l0, "process_l0_last_steps", new=AsyncMock())
+    flow_params = MagicMock(session_collection="s03-cadip-session")
+
+    await s3_l0.process_s3l0.fn("S3A_session", flow_params, verbose=False)
+
+    last_steps.assert_awaited_once()
+    kwargs = last_steps.call_args.kwargs
+    assert kwargs["mission"] == "3"
+    products = kwargs["input_products"]
+    assert products[0].name == "S3ACADUS"
+    assert products[0].collection_name == "s03-cadip-session"
+
+
+async def test_process_s1l0_task_delegates_to_flow(mocker):
+    """The S1 task wrapper simply runs the underlying flow function."""
+    delegate = mocker.patch.object(s1_l0.process_s1l0, "fn", new=AsyncMock())
+    await s1_l0.process_s1l0_task.fn(session="S1A_session", flow_params=MagicMock(), verbose=False)
+    delegate.assert_awaited_once()
+
+
+async def test_process_s3l0_task_delegates_to_flow(mocker):
+    """The S3 task wrapper simply runs the underlying flow function."""
+    delegate = mocker.patch.object(s3_l0.process_s3l0, "fn", new=AsyncMock())
+    await s3_l0.process_s3l0_task.fn(session="S3A_session", flow_params=MagicMock(), verbose=False)
+    delegate.assert_awaited_once()

--- a/tests/test_on_demand_staging.py
+++ b/tests/test_on_demand_staging.py
@@ -1,0 +1,292 @@
+# Copyright 2023-2026 Airbus, CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for rs_workflows.on_demand.common.staging."""
+
+from datetime import timedelta
+from enum import Enum
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rs_workflows.flow_utils import FlowEnvArgs
+from rs_workflows.on_demand.common import staging
+from rs_workflows.on_demand.common.staging import (
+    CadipCollections,
+    cadip_session_stage,
+    create_result_artifact,
+    make_session_enum,
+    stage_latest_session,
+    stage_selected_session,
+    stage_session_common,
+)
+
+
+def _flow_env_mock():
+    """Return a FlowEnv mock whose start_span() works as a context manager."""
+    flow_env = MagicMock()
+    flow_env.start_span.return_value.__enter__.return_value = MagicMock()
+    return flow_env
+
+
+# --------------------------------------------------------------------------- #
+# make_session_enum / CadipCollections
+# --------------------------------------------------------------------------- #
+def test_make_session_enum_inverts_mapping():
+    """make_session_enum turns {id: label} into an Enum {label: id}."""
+    result = make_session_enum({"id-1": "label one", "id-2": "label two"})
+    assert issubclass(result, Enum)  # type: ignore[arg-type]
+    assert result["label one"].value == "id-1"  # type: ignore[index]
+    assert result["label two"].value == "id-2"  # type: ignore[index]
+
+
+def test_cadip_collection_satellite_index():
+    """The second character of a CADIP collection identifies the satellite number."""
+    assert CadipCollections.S1_SGS[1] == "1"
+    assert CadipCollections.S3_SGS[1] == "3"
+
+
+# --------------------------------------------------------------------------- #
+# create_result_artifact
+# --------------------------------------------------------------------------- #
+async def test_create_result_artifact_builds_markdown_and_link(mocker):
+    """The result artifact contains the session id/duration and a monitoring link."""
+    markdown_mock = AsyncMock()
+    link_mock = AsyncMock()
+    mocker.patch.object(staging, "acreate_markdown_artifact", markdown_mock)
+    mocker.patch.object(staging, "acreate_link_artifact", link_mock)
+    mocker.patch.object(staging, "get_run_logger", return_value=MagicMock())
+
+    await create_result_artifact.fn("SESSION_42", timedelta(seconds=90))
+
+    markdown = markdown_mock.call_args.kwargs["markdown"]
+    assert "SESSION_42" in markdown
+    assert "0:01:30" in markdown  # str(timedelta(seconds=90))
+    link_mock.assert_awaited_once()
+    assert "from=" in link_mock.call_args.kwargs["link"]
+    assert "to=" in link_mock.call_args.kwargs["link"]
+
+
+# --------------------------------------------------------------------------- #
+# cadip_session_stage
+# --------------------------------------------------------------------------- #
+async def test_cadip_session_stage_returns_status_for_host(mocker):
+    """cadip_session_stage returns the status keyed by the search URL hostname."""
+    flow_env = _flow_env_mock()
+    staging_client = flow_env.rs_client.get_staging_client.return_value
+    staging_client.run_staging.return_value = "job-status"
+    staging_client.wait_for_jobs.return_value = {"cadip.example.com": {"status": "successful"}}
+    mocker.patch.object(staging, "FlowEnv", return_value=flow_env)
+    mocker.patch.object(staging, "get_run_logger", return_value=MagicMock())
+
+    result = await cadip_session_stage.fn(
+        FlowEnvArgs(owner_id="owner"),
+        "https://cadip.example.com/search?ids=SESSION_42",
+        "s01-cadip-session",
+    )
+
+    assert result == "successful"
+    staging_client.run_staging.assert_called_once_with(
+        "https://cadip.example.com/search?ids=SESSION_42",
+        "s01-cadip-session",
+    )
+
+
+async def test_cadip_session_stage_missing_status_returns_empty(mocker):
+    """A host entry without a status yields an empty string."""
+    flow_env = _flow_env_mock()
+    staging_client = flow_env.rs_client.get_staging_client.return_value
+    staging_client.wait_for_jobs.return_value = {"cadip.example.com": {}}
+    mocker.patch.object(staging, "FlowEnv", return_value=flow_env)
+    mocker.patch.object(staging, "get_run_logger", return_value=MagicMock())
+
+    result = await cadip_session_stage.fn(
+        FlowEnvArgs(owner_id="owner"),
+        "https://cadip.example.com/search?ids=SESSION",
+        "s01-cadip-session",
+    )
+    assert result == ""
+
+
+# --------------------------------------------------------------------------- #
+# stage_session_common
+# --------------------------------------------------------------------------- #
+def _patch_stage_session_common(mocker, status):
+    """Patch the collaborators used by stage_session_common; return its mocks."""
+    mocker.patch.object(staging, "get_run_logger", return_value=MagicMock())
+    check_mock = mocker.patch.object(staging, "check_and_create_collection", new=AsyncMock())
+
+    stage_mock = mocker.patch.object(staging, "cadip_session_stage")
+    stage_mock.submit.return_value.result.return_value = status
+
+    artifact_mock = mocker.patch.object(staging, "create_result_artifact")
+    artifact_mock.submit.return_value.result.return_value = None
+
+    return check_mock, stage_mock, artifact_mock
+
+
+async def test_stage_session_common_success(mocker):
+    """A successful staging returns True and builds the expected collection name."""
+    check_mock, stage_mock, _ = _patch_stage_session_common(mocker, "successful")
+    flow_env = MagicMock()
+    report = MagicMock()
+
+    result = await stage_session_common.fn(flow_env, CadipCollections.S1_SGS, "SESSION_42", report)
+
+    assert result is True
+    check_mock.assert_awaited_once_with(flow_env, "s01-cadip-session")
+    report.success_step.assert_called_once()
+    # the staging task is submitted with the session id inside the search URL
+    assert "SESSION_42" in stage_mock.submit.call_args.kwargs["cadip_search_url"]
+
+
+async def test_stage_session_common_failure(mocker):
+    """A non-successful staging returns False and reports the failure."""
+    _patch_stage_session_common(mocker, "failed")
+    flow_env = MagicMock()
+    report = MagicMock()
+
+    result = await stage_session_common.fn(flow_env, CadipCollections.S3_SGS, "SESSION", report)
+
+    assert result is False
+    report.failed_step.assert_called_once()
+
+
+async def test_stage_session_common_works_without_report(mocker):
+    """The report manager is optional."""
+    _patch_stage_session_common(mocker, "successful")
+    result = await stage_session_common.fn(MagicMock(), CadipCollections.S1_SGS, "SESSION")
+    assert result is True
+
+
+# --------------------------------------------------------------------------- #
+# stage_latest_session
+# --------------------------------------------------------------------------- #
+async def test_stage_latest_session_raises_when_no_session(mocker):
+    """When no session is found, the flow raises ValueError."""
+    flow_env = _flow_env_mock()
+    mocker.patch.object(staging, "FlowEnv", return_value=flow_env)
+    mocker.patch.object(staging, "get_run_logger", return_value=MagicMock())
+    search_mock = mocker.patch.object(staging, "cadip_session_search")
+    search_mock.submit.return_value.result.return_value = []
+
+    with pytest.raises(ValueError, match="No Cadip session found"):
+        await stage_latest_session.fn(CadipCollections.S1_SGS)
+
+
+async def test_stage_latest_session_stages_found_session(mocker):
+    """The latest session found is forwarded to stage_session_common."""
+    flow_env = _flow_env_mock()
+    mocker.patch.object(staging, "FlowEnv", return_value=flow_env)
+    mocker.patch.object(staging, "get_run_logger", return_value=MagicMock())
+    search_mock = mocker.patch.object(staging, "cadip_session_search")
+    search_mock.submit.return_value.result.return_value = [MagicMock(id="SESSION_42")]
+    stage_common = mocker.patch.object(staging, "stage_session_common", new=AsyncMock())
+
+    await stage_latest_session.fn(CadipCollections.S1_SGS)
+
+    stage_common.assert_awaited_once_with(flow_env, CadipCollections.S1_SGS, "SESSION_42", None)
+
+
+async def test_stage_latest_session_verbose_pushes_report(mocker):
+    """In verbose mode a ReportManager report is pushed at the end."""
+    flow_env = _flow_env_mock()
+    mocker.patch.object(staging, "FlowEnv", return_value=flow_env)
+    mocker.patch.object(staging, "get_run_logger", return_value=MagicMock())
+    search_mock = mocker.patch.object(staging, "cadip_session_search")
+    search_mock.submit.return_value.result.return_value = [MagicMock(id="SESSION_42")]
+    mocker.patch.object(staging, "stage_session_common", new=AsyncMock())
+
+    report_instance = MagicMock()
+    report_instance.push_report = AsyncMock()
+    mocker.patch.object(staging, "ReportManager", return_value=report_instance)
+
+    await stage_latest_session.fn(CadipCollections.S1_SGS, verbose=True)
+
+    report_instance.success_step.assert_called_once()
+    report_instance.push_report.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+# stage_selected_session (early no-session branch)
+# --------------------------------------------------------------------------- #
+async def test_stage_selected_session_raises_when_no_session(mocker):
+    """stage_selected_session raises ValueError when no session is found."""
+    flow_env = _flow_env_mock()
+    mocker.patch.object(staging, "FlowEnv", return_value=flow_env)
+    mocker.patch.object(staging, "get_run_logger", return_value=MagicMock())
+    search_mock = mocker.patch.object(staging, "cadip_session_search")
+    search_mock.submit.return_value.result.return_value = None
+
+    with pytest.raises(ValueError, match="No Cadip session found"):
+        await stage_selected_session.fn(CadipCollections.S1_SGS)
+
+
+async def test_stage_selected_session_stages_user_choice(mocker):
+    """stage_selected_session builds the session list, pauses for input, then stages the choice."""
+    flow_env = _flow_env_mock()
+    mocker.patch.object(staging, "FlowEnv", return_value=flow_env)
+    mocker.patch.object(staging, "get_run_logger", return_value=MagicMock())
+
+    published, orbit = "2023-01-01T00:00:00Z", 123
+    item = MagicMock(id="SESSION_42")
+    item.properties = {"published": published, "sat:absolute_orbit": orbit}
+    search_mock = mocker.patch.object(staging, "cadip_session_search")
+    search_mock.submit.return_value.result.return_value = MagicMock(items=[item])
+
+    # The paused input returns the enum value, which is the display key of the session.
+    display_key = f"📡 SESSION_42 🕒 {published} 🌍 {orbit}"
+    selection = MagicMock()
+    selection.selected.value = display_key
+    mocker.patch.object(staging, "apause_flow_run", new=AsyncMock(return_value=selection))
+    stage_common = mocker.patch.object(staging, "stage_session_common", new=AsyncMock())
+
+    await stage_selected_session.fn(CadipCollections.S1_SGS)
+
+    stage_common.assert_awaited_once_with(flow_env, CadipCollections.S1_SGS, "SESSION_42")
+
+
+async def test_stage_latest_session_verbose_no_session_reports_failure(mocker):
+    """In verbose mode, a missing session records a failed step before raising."""
+    flow_env = _flow_env_mock()
+    mocker.patch.object(staging, "FlowEnv", return_value=flow_env)
+    mocker.patch.object(staging, "get_run_logger", return_value=MagicMock())
+    search_mock = mocker.patch.object(staging, "cadip_session_search")
+    search_mock.submit.return_value.result.return_value = []
+    report_instance = MagicMock()
+    report_instance.push_report = AsyncMock()
+    mocker.patch.object(staging, "ReportManager", return_value=report_instance)
+
+    with pytest.raises(ValueError, match="No Cadip session found"):
+        await stage_latest_session.fn(CadipCollections.S1_SGS, verbose=True)
+
+    report_instance.failed_step.assert_called_once()
+
+
+async def test_stage_latest_session_none_id_does_not_stage(mocker):
+    """A found session with a None id is not staged and is reported as missing."""
+    flow_env = _flow_env_mock()
+    mocker.patch.object(staging, "FlowEnv", return_value=flow_env)
+    mocker.patch.object(staging, "get_run_logger", return_value=MagicMock())
+    search_mock = mocker.patch.object(staging, "cadip_session_search")
+    search_mock.submit.return_value.result.return_value = [MagicMock(id=None)]
+    stage_common = mocker.patch.object(staging, "stage_session_common", new=AsyncMock())
+    report_instance = MagicMock()
+    report_instance.push_report = AsyncMock()
+    mocker.patch.object(staging, "ReportManager", return_value=report_instance)
+
+    await stage_latest_session.fn(CadipCollections.S1_SGS, verbose=True)
+
+    stage_common.assert_not_awaited()
+    report_instance.failed_step.assert_called_once()

--- a/tests/test_on_demand_types.py
+++ b/tests/test_on_demand_types.py
@@ -1,0 +1,141 @@
+# Copyright 2023-2026 Airbus, CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for rs_workflows.on_demand.common.types."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rs_workflows.flow_utils import (
+    LoggingLevel,
+    Priority,
+    ProcessingMode,
+    WorkflowType,
+)
+from rs_workflows.on_demand.common import types
+from rs_workflows.on_demand.common.types import (
+    DEFAULT_PREFECT_CONFIGURATION,
+    Level0FlowParams,
+    ProcessingFlowParams,
+)
+
+
+def _patch_variable(mocker, value):
+    """Patch the Prefect Variable.get used by ProcessingFlowParams._resolve."""
+    mocker.patch.object(types.Variable, "get", new=AsyncMock(return_value=value))
+
+
+def test_default_prefect_configuration_format():
+    """The default configuration template resolves to the sX-lY variable name."""
+    assert DEFAULT_PREFECT_CONFIGURATION.format(mission="1", level="0") == "s1-l0-default-setting"
+
+
+def test_resolve_specific_base_returns_empty():
+    """The base ProcessingFlowParams injects no mission-specific field."""
+    # pylint: disable=protected-access
+    assert not ProcessingFlowParams()._resolve_specific({"anything": 1})
+
+
+async def test_resolve_raises_when_variable_missing(mocker):
+    """A missing Prefect variable raises FileExistsError with the variable name."""
+    _patch_variable(mocker, None)
+    with pytest.raises(FileExistsError, match="s1-l0-default-setting"):
+        await Level0FlowParams().resolve("1")
+
+
+async def test_resolve_uses_defaults_when_raw_not_dict(mocker):
+    """A non-dict variable payload is treated as empty settings (defaults kept)."""
+    _patch_variable(mocker, "not-a-dict")
+    resolved = await Level0FlowParams().resolve("1")
+    assert resolved.owner_identifier == ""
+    assert resolved.dask_cluster_label == ""
+    assert resolved.pipeline is None
+    assert resolved.unit is None
+    assert resolved.cadip_collections == []
+    assert resolved.logging_level == LoggingLevel.INFO
+
+
+async def test_resolve_pipeline_and_unit_are_mutually_exclusive(mocker):
+    """Setting both pipeline and unit is rejected."""
+    _patch_variable(mocker, {})
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        await Level0FlowParams(pipeline="my-pipe", unit="my-unit").resolve("1")
+
+
+async def test_resolve_user_pipeline_takes_precedence(mocker):
+    """A user-provided pipeline wins over settings and clears the unit."""
+    _patch_variable(mocker, {"pipeline": "settings-pipe", "unit": "settings-unit"})
+    resolved = await Level0FlowParams(pipeline="user-pipe").resolve("1")
+    assert resolved.pipeline == "user-pipe"
+    assert resolved.unit is None
+
+
+async def test_resolve_user_unit_takes_precedence(mocker):
+    """A user-provided unit wins over settings and clears the pipeline."""
+    _patch_variable(mocker, {"pipeline": "settings-pipe"})
+    resolved = await Level0FlowParams(unit="user-unit").resolve("1")
+    assert resolved.unit == "user-unit"
+    assert resolved.pipeline is None
+
+
+async def test_resolve_falls_back_to_settings_pipeline(mocker):
+    """When neither is provided, pipeline/unit come from the settings."""
+    _patch_variable(mocker, {"pipeline": "settings-pipe"})
+    resolved = await Level0FlowParams().resolve("1")
+    assert resolved.pipeline == "settings-pipe"
+    assert resolved.unit is None
+
+
+async def test_resolve_merges_settings_and_params(mocker):
+    """Parameters override settings; empty parameters are filled from settings."""
+    settings = {
+        "owner_identifier": "settings-owner",
+        "dask_cluster_name": "settings-cluster",
+        "processor": {"name": "proc", "version": "1.2.3"},
+        "priority": "high",
+        "processing_mode": ["nrt"],
+        "workflow": "on-demand",
+        "session_collection": "s1-cadip-sessions",
+        "cadip_collections": ["s1_sgs", "s1_mps"],
+        "generated_product_to_collection_identifier": [
+            {"name": "GP", "product_type": "T", "collection_name": "C"},
+        ],
+        "auxiliary_product_to_collection_identifier": [
+            {"product_type": "AX", "collection_name": "AUX"},
+        ],
+    }
+    _patch_variable(mocker, settings)
+
+    resolved = await Level0FlowParams(owner_identifier="param-owner").resolve("1")
+
+    assert resolved.owner_identifier == "param-owner"  # parameter wins
+    assert resolved.dask_cluster_label == "settings-cluster"  # settings key is dask_cluster_name
+    assert resolved.processor_name == "proc"
+    assert resolved.processor_version == "1.2.3"
+    assert resolved.priority == Priority.HIGH
+    assert resolved.processing_mode == [ProcessingMode.NRT]
+    assert resolved.workflow == WorkflowType.ON_DEMAND
+    assert resolved.session_collection == "s1-cadip-sessions"
+    assert resolved.cadip_collections == ["s1_sgs", "s1_mps"]
+    assert resolved.generated_product_to_collection_identifier[0].name == "GP"  # type: ignore[index]
+    assert resolved.auxiliary_product_to_collection_identifier[0].product_type == "AX"  # type: ignore[index]
+
+
+async def test_resolve_uses_correct_variable_name_per_mission(mocker):
+    """The resolved Prefect variable name embeds the mission and level 0."""
+    get_mock = AsyncMock(return_value={})
+    mocker.patch.object(types.Variable, "get", new=get_mock)
+    await Level0FlowParams().resolve("3")
+    get_mock.assert_awaited_once_with("s3-l0-default-setting")


### PR DESCRIPTION
The rs_workflows/on_demand package (adf, common, sentinel1, sentinel3) had no test coverage. Add four test modules bringing it to ~98% line coverage:

- tests/test_on_demand_types.py: ProcessingFlowParams/Level0FlowParams resolution (settings/params merge, pipeline vs unit exclusivity, missing/invalid variable).
- tests/test_on_demand_staging.py: make_session_enum, CadipCollections, result artifact, cadip_session_stage, stage_session_common and the stage_*_session flows.
- tests/test_on_demand_l0.py: process_l0 branching (validation, eviction, staging, mission dispatch), process_l0_last_steps and the S1/S3 entry points.
- tests/test_on_demand_adf.py: compute_cql2, convert_adf_group, past_adf_conversion, schedule_adf_conversion, adf_conversion_scheduled and schedule_conversion_flow.

Prefect variables, flow environment, tasks and sub-flows are mocked so the tests run without a live Prefect server or S3 backend.