### PR TITLE
Conversion flow: Remove .zarr suffix only if the id looks like a valid EOPF id

### DIFF
--- a/rs_workflows/on_demand_conversion.py
+++ b/rs_workflows/on_demand_conversion.py
@@ -109,7 +109,11 @@ def read_zarr_stac_item(zarr_uri: str) -> Item:
 
     # Reuse the existing DPR STAC builder so the SAFE conversion output follows
     # the same catalog item shape as the other DPR products.
-    item_id = os.path.basename(zarr_uri.removesuffix(".zarr"))
+    item_id = os.path.basename(zarr_uri)
+    # Remove .zarr suffix if the id looks like a valid EOPF id, otherwise keep it
+    # to avoid potential conflict with existing legacy product in catalogue
+    if item_id.startswith("S0"):
+        item_id = item_id.removesuffix(".zarr")
     return create_stac_item(
         eopf_origin_datetime=None,
         eopf_feature=stac_discovery,

--- a/tests/test_on_demand_conversion.py
+++ b/tests/test_on_demand_conversion.py
@@ -81,7 +81,7 @@ async def test_on_demand_conversion_helpers_cover_mapping_zarr_and_safe_task(tmp
     # 2. Zarr STAC discovery.
     # read_zarr_stac_item reads the root .zattrs file written by EOPF and builds
     # the STAC item through the same create_stac_item helper used by DPR flows.
-    zarr_dir = tmp_path / "S1A_SAFE_CONVERTED.zarr"
+    zarr_dir = tmp_path / "S01SIWSLC_SAFE_CONVERTED.zarr"
     zarr_dir.mkdir()
     (zarr_dir / ".zattrs").write_text(
         json.dumps(
@@ -101,9 +101,9 @@ async def test_on_demand_conversion_helpers_cover_mapping_zarr_and_safe_task(tmp
 
     stac_item = on_demand_conversion_flow.read_zarr_stac_item(str(zarr_dir))
 
-    assert stac_item.id == "S1A_SAFE_CONVERTED"
+    assert stac_item.id == "S01SIWSLC_SAFE_CONVERTED"
     assert stac_item.properties["product:type"] == output_product_type
-    assert stac_item.assets["S1A_SAFE_CONVERTED"].href == str(zarr_dir)
+    assert stac_item.assets["S01SIWSLC_SAFE_CONVERTED"].href == str(zarr_dir)
 
     # Missing stac_discovery metadata is treated as a conversion output problem
     # and should fail before publication.


### PR DESCRIPTION
Right now CPM 2.8.1 does not produce a valid id when converting a S1_IW_SLC product.

The ouput folder is named with the legacy id, and the .zattrs file contains "SAR Standard L1 Product" instead of a valid EOPF id.

See https://gitlab.eopf.copernicus.eu/cpm/eopf-cpm/-/issues/1137

This leads our flow to add the converted product in our catalogue using the legacy id. Which causes a conflict if we have the legacy product in the catalogue.

Quick solution: in this case keep the zarr suffix in the output id to avoid the conflict.