### PR TITLE
RSPY 1079: Make rs-dpr-service retrieve DASK_GATEWAY_ADDRESS dynamically

### DIFF
--- a/.github/scripts/call_prefect.py
+++ b/.github/scripts/call_prefect.py
@@ -21,16 +21,16 @@ See: https://docs.prefect.io/v3/api-ref/rest-api
 NOTE:
 The PREFECT_CONFIG_DEV and PREFECT_CONFIG_OPS variables are defined in
 https://github.com/RS-PYTHON/rs-client-libraries/settings/variables/actions
-It should have yaml content as:
+They should have yaml content as:
 prefect_public_url: https://<prefect-public-domain>
 
 The PREFECT_CREDENTIALS_DEV and PREFECT_CREDENTIALS_OPS secrets are defined in
 https://github.com/RS-PYTHON/rs-client-libraries/settings/secrets/actions
 These values are set with the admin-dev account on
 https://admin.iam.example.com/admin/master/console for the Prefect service.
-It should have yaml content as:
-keycloak_token_url: ***
-client_id: ***
+They should have yaml content as:
+keycloak_token_url: https://iam.example.com/realms/rspy/protocol/openid-connect/token
+client_id: *** (new client to use the prefect api)
 client_secret: ***
 """
 

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -179,6 +179,14 @@ jobs:
           # Run the rs-demo local mode using the newly created docker images
           ./test-rs-demo.sh
 
+      - name: Upload executed notebooks
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: notebook-outputs
+          path: local-mode/notebook-outputs/
+          if-no-files-found: ignore
+
       # If we used a temp docker tag, and only if the tests succeeded, then
       # we tag the images with the real tags and push them.
       - name: Tag and push Docker images

--- a/rs_client/ogcapi/dpr_client.py
+++ b/rs_client/ogcapi/dpr_client.py
@@ -70,12 +70,14 @@ class ClusterInfo:
 
     Attributes:
         jupyter_token: JupyterHub API token. Only used in cluster mode, not local mode.
+        dask_gateway_address: Dask gateway address, defined in Jupyter, with a different value for each organization.
         cluster_label: Dask cluster label e.g. "dask-l0"
         cluster_instance: Dask cluster instance ID (something like "dask-gateway.17e196069443463495547eb97f532834").
         If instance is empty, the DPR processor will use the first cluster with the given label.
     """
 
     jupyter_token: str
+    dask_gateway_address: str
     cluster_label: str
     cluster_instance: str | None = ""
 

--- a/rs_common/prefect_utils.py
+++ b/rs_common/prefect_utils.py
@@ -214,7 +214,7 @@ async def init_prefect_blocks():
         ]:
             global_env_vars[key] = os.environ[key]
 
-        # These ones are used only in cluster mode. In local mode we give empty values.
+        # These ones are used only in cluster mode. In local mode we set empty values.
         for key in [
             "JUPYTERHUB_API_TOKEN",
             "DASK_GATEWAY_ADDRESS",

--- a/rs_common/prefect_utils.py
+++ b/rs_common/prefect_utils.py
@@ -214,6 +214,13 @@ async def init_prefect_blocks():
         ]:
             global_env_vars[key] = os.environ[key]
 
+        # These ones are used only in cluster mode. In local mode we give empty values.
+        for key in [
+            "JUPYTERHUB_API_TOKEN",
+            "DASK_GATEWAY_ADDRESS",
+        ]:
+            global_env_vars[key] = ""
+
         # Save env vars in a secret block for all users
         await update_prefect_block(BLOCK_NAME_ENV_GLOBAL, global_env_vars)
 

--- a/rs_workflows/on_demand_conversion.py
+++ b/rs_workflows/on_demand_conversion.py
@@ -25,7 +25,6 @@ from pystac import Item, ItemCollection, Link
 
 from rs_client.ogcapi.dpr_client import ClusterInfo, DprClient
 from rs_client.stac.catalog_client import CatalogClient
-from rs_common import prefect_utils
 from rs_workflows import catalog_flow
 from rs_workflows.dpr_flow import create_stac_item
 from rs_workflows.flow_utils import (
@@ -329,10 +328,9 @@ async def on_demand_conversion(
             "output_zarr_dir_path": output_zarr_dir_path,
         }
 
-        # Create cluster info from JUPYTERHUB_API_TOKEN env var (only in cluster mode, read from the
-        # prefect blocks) and Dask cluster label.
         cluster_info = ClusterInfo(
-            jupyter_token=os.environ["JUPYTERHUB_API_TOKEN"] if prefect_utils.CLUSTER_MODE else "",
+            jupyter_token=os.environ["JUPYTERHUB_API_TOKEN"],
+            dask_gateway_address=os.environ["DASK_GATEWAY_ADDRESS"],
             cluster_label=conversion_input.dask_cluster_label,
             cluster_instance=conversion_input.dask_cluster_instance or "",
         )

--- a/rs_workflows/on_demand_processing.py
+++ b/rs_workflows/on_demand_processing.py
@@ -397,10 +397,9 @@ async def dpr_processing(
 
     with flow_env.start_span(__name__, "dpr-processing"):
 
-        # Create cluster info from JUPYTERHUB_API_TOKEN env var (only in cluster mode, read from the
-        # prefect blocks) and Dask cluster label.
         cluster_info = ClusterInfo(
-            jupyter_token=os.environ["JUPYTERHUB_API_TOKEN"] if prefect_utils.CLUSTER_MODE else "",
+            jupyter_token=os.environ["JUPYTERHUB_API_TOKEN"],
+            dask_gateway_address=os.environ["DASK_GATEWAY_ADDRESS"],
             cluster_label=dpr_input.dask_cluster_label,
             cluster_instance=dpr_input.dask_cluster_instance or "",
         )

--- a/tests/test_dpr.py
+++ b/tests/test_dpr.py
@@ -29,7 +29,7 @@ from tests.conftest import MOCKED_RSPY_WEBSITE
 
 RS_SERVER_API_KEY = "RS_SERVER_API_KEY"
 OWNER_ID = getpass.getuser()
-CLUSTER_INFO = ClusterInfo("", "", "")
+CLUSTER_INFO = ClusterInfo("", "", "", "")
 
 
 @pytest.fixture(name="dpr_client")

--- a/tests/test_dpr_flow_helper.py
+++ b/tests/test_dpr_flow_helper.py
@@ -40,7 +40,7 @@ from rs_workflows.payload_generator import RSPY_CATALOG_BUCKET
 from tests.conftest import MOCKED_BUCKET, OWNER_ID
 from tests.test_utils import setup_worklow_test_env
 
-CLUSTER_INFO = ClusterInfo("", "", "")
+CLUSTER_INFO = ClusterInfo("", "", "", "")
 
 
 def test_s3_list_returns_full_s3_paths(mocker):

--- a/tests/test_ogcapi.py
+++ b/tests/test_ogcapi.py
@@ -35,7 +35,7 @@ from tests.conftest import MOCKED_RSPY_WEBSITE
 RS_SERVER_API_KEY = "RS_SERVER_API_KEY"
 OWNER_ID = getpass.getuser()
 TIMEOUT = 5
-CLUSTER_INFO = ClusterInfo("", "", "")
+CLUSTER_INFO = ClusterInfo("", "", "", "")
 
 logger = Logging.default(__name__)
 

--- a/tests/test_on_demand_conversion.py
+++ b/tests/test_on_demand_conversion.py
@@ -132,6 +132,7 @@ async def test_on_demand_conversion_helpers_cover_mapping_zarr_and_safe_task(tmp
     }
     cluster_info = on_demand_conversion_flow.ClusterInfo(
         jupyter_token="",
+        dask_gateway_address="",
         cluster_label="dask-safe",
         cluster_instance="dask-instance-1",
     )
@@ -223,7 +224,8 @@ async def test_on_demand_conversion_orchestrates_safe_conversion_happy_path(monk
     converted_item.add_asset("converted-product", Asset(href="s3://output-bucket/zarr/converted-product.zarr"))
 
     mocker.patch.object(on_demand_conversion_flow, "get_run_logger", return_value=MagicMock())
-    monkeypatch.setattr(on_demand_conversion_flow.prefect_utils, "CLUSTER_MODE", False)
+    monkeypatch.setenv("JUPYTERHUB_API_TOKEN", "")
+    monkeypatch.setenv("DASK_GATEWAY_ADDRESS", "")
     monkeypatch.setenv("RSPY_HOST_OSAM", "https://osam.test")
 
     flow_env_mock = MagicMock()
@@ -318,6 +320,7 @@ async def test_on_demand_conversion_orchestrates_safe_conversion_happy_path(monk
         "output_zarr_dir_path": f"s3://output-bucket/{owner_id}/{output_collection}",
     }
     assert cluster_info.jupyter_token == ""
+    assert cluster_info.dask_gateway_address == ""
     assert cluster_info.cluster_label == "dask-safe"
     assert cluster_info.cluster_instance == "dask-instance-1"
 

--- a/tests/test_prefect_utils.py
+++ b/tests/test_prefect_utils.py
@@ -97,7 +97,6 @@ async def test_init_prefect_blocks(monkeypatch, mock_prefect, local_mode):  # py
         "POSTGRES_HOST": "test_host",
         "POSTGRES_PORT": "5432",
         "POSTGRES_PI_DB": "test_db",
-        "DASK_GATEWAY_ADDRESS": "DASK_GATEWAY_ADDRESS",
         "LOCAL_DASK_USERNAME": "LOCAL_DASK_USERNAME",
         "LOCAL_DASK_PASSWORD": "LOCAL_DASK_PASSWORD",
     }
@@ -106,6 +105,13 @@ async def test_init_prefect_blocks(monkeypatch, mock_prefect, local_mode):  # py
     if local_mode:
         for key, value in env_global.items():
             monkeypatch.setenv(key, value)
+
+        # These ones will be set by the prefect init
+        for key in [
+            "JUPYTERHUB_API_TOKEN",
+            "DASK_GATEWAY_ADDRESS",
+        ]:
+            env_global[key] = ""
 
     # In cluster mode, they must be set in a prefect block
     else:
@@ -165,7 +171,7 @@ async def test_init_prefect_blocks(monkeypatch, mock_prefect, local_mode):  # py
     assert env_global == (await Secret.load(prefect_utils.BLOCK_NAME_ENV_GLOBAL)).get()
     assert env_user == (await Secret.load(user_block_name)).get()
 
-    # Check that the values were save as env vars
+    # Check that the values were saved as env vars
     for key, value in {**env_global, **env_user}.items():
         assert os.environ[key] == value
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -86,7 +86,9 @@ def _mocked_tasktable():
     with open(CONFIG_DIR / "tasktable.json", encoding="utf-8") as f:
         responses.get(
             url=f"{MOCKED_RSPY_WEBSITE}/dpr/processes/mockup?"
-            f"jupyter_token={JUPYTERHUB_API_TOKEN}&cluster_label={DASK_CLUSTER_LABEL}"
+            f"jupyter_token={JUPYTERHUB_API_TOKEN}"
+            f"&dask_gateway_address={DASK_GATEWAY_ADDRESS}"
+            f"&cluster_label={DASK_CLUSTER_LABEL}"
             f"&cluster_instance={DASK_CLUSTER_INSTANCE}",
             json=json.load(f),
             status=status.HTTP_200_OK,
@@ -488,18 +490,10 @@ async def test_dpr_processing_raises_on_unstaged_adf(
     # Init and run #
     ################
 
-    with open(CONFIG_DIR / "tasktable.json", encoding="utf-8") as f:
-        responses.get(
-            url=f"{MOCKED_RSPY_WEBSITE}/dpr/processes/mockup?"
-            f"jupyter_token={JUPYTERHUB_API_TOKEN}&cluster_label=dask-eopf-mockup"
-            f"&cluster_instance={DASK_CLUSTER_INSTANCE}",
-            json=json.load(f),
-            status=status.HTTP_200_OK,
-        )
-
     await setup_worklow_test_env(
         {
             "JUPYTERHUB_API_TOKEN": JUPYTERHUB_API_TOKEN,
+            "DASK_GATEWAY_ADDRESS": DASK_GATEWAY_ADDRESS,
             "DASK_GATEWAY_EOPF_MOCKUP_PUBLIC": DASK_GATEWAY_PUBLIC,
         },
     )
@@ -509,7 +503,7 @@ async def test_dpr_processing_raises_on_unstaged_adf(
         processor_name="mockup",
         processor_version="1.0",
         pipeline="mockup_full",
-        dask_cluster_label="dask-eopf-mockup",
+        dask_cluster_label=DASK_CLUSTER_LABEL,
         dask_cluster_instance=DASK_CLUSTER_INSTANCE,
         input_products=[
             FlowInputProduct(name="input_name", item_id="stac_item_id", collection_name="collection_name"),

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -65,6 +65,7 @@ STORAGE_CONFIG = "processing-storage-configuration"
 ##################
 
 JUPYTERHUB_API_TOKEN = "JUPYTERHUB_API_TOKEN"
+DASK_GATEWAY_ADDRESS = "DASK_GATEWAY_ADDRESS"
 DASK_CLUSTER_LABEL = "DASK_CLUSTER_LABEL"
 DASK_CLUSTER_INSTANCE = "dask-gateway.test-cluster-instance"
 DASK_GATEWAY_PUBLIC = "http://test-dask-gateway-public"
@@ -188,6 +189,7 @@ async def test_dpr_processing(
     await setup_worklow_test_env(
         {
             "JUPYTERHUB_API_TOKEN": JUPYTERHUB_API_TOKEN,
+            "DASK_GATEWAY_ADDRESS": DASK_GATEWAY_ADDRESS,
             "DASK_GATEWAY_PUBLIC": DASK_GATEWAY_PUBLIC,
             "RSPY_HOST_OSAM": "https://dummy-osam",
         },


### PR DESCRIPTION
https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-1079

- https://github.com/RS-PYTHON/rs-dpr-service/pull/142
- https://github.com/RS-PYTHON/rs-demo/pull/343
- https://github.com/RS-PYTHON/rs-client-libraries/pull/366
- https://github.com/RS-PYTHON/rs-helm/pull/265

Before these PRs: 

1. The `DASK_GATEWAY_ADDRESS` is defined as an env var in Jupyter (from the helm charts of Jupyter)
2. It is used to create the `env-vars` Prefect secret block
3. Prefect flow read the dask gateway address value from the secret block
4. rs-dpr-service also reads `DASK_GATEWAY_ADDRESS` as an env var (from the helm charts of rs-dpr-service)

With these PRs, the first 3 points stay the same, but 4) is changing: the Prefect flows call rs-dpr-service by passing it the `dask_gateway_address` value to use (it is added to the `ClusterInfo` object)