### PR TITLE
RSPY-1044 - Honor collection_name when searching AUX products in the catalog

### DIFF
--- a/rs_workflows/adf_flow.py
+++ b/rs_workflows/adf_flow.py
@@ -429,6 +429,23 @@ async def adf_conversion(adf_input: AdfProcessIn):
 
         staged_items: list[Item] = []
         for prod_type in required_types:
+            # find target collection from mapping, preferring an exact product type match
+            target_collection = resolve_collection_name(
+                adf_input.auxiliary_product_to_collection_identifier,
+                prod_type,
+            )
+            if target_collection is None:
+                raise RuntimeError(
+                    "❌ No target collection found for input product type "
+                    f"{prod_type!r} in auxiliary_product_to_collection_identifier.",
+                )
+
+            # find source from mapping
+            source: AuxiliarySource = resolve_source_name(
+                adf_input.auxiliary_product_to_collection_identifier,
+                prod_type,
+            )
+
             cql2_filter: dict = {}
             if adf_input.cql2_filter is not None:
                 logger.info("🧹 Use the provided CQL2 filter for auxiliary data retrieval")
@@ -456,24 +473,17 @@ async def adf_conversion(adf_input: AdfProcessIn):
                         ],
                     },
                 }
+
+            # When the source is the catalog, no staging occurs: collection_name is both the source
+            # and destination collection, so the search must be restricted to it, otherwise the STAC
+            # search returns the most recent matching item across all collections (e.g. another OLCI
+            # baseline collection). For other sources, collection_name is only the destination
+            # collection where staged items will be uploaded, and must not be used to filter the
+            # search performed against the external source.
+            if source == AuxiliarySource.CATALOG:
+                cql2_filter["collections"] = [target_collection]
+
             logger.info(f"Built CQL2 filter for product type {prod_type}: {cql2_filter}")
-
-            # find target collection from mapping, preferring an exact product type match
-            target_collection = resolve_collection_name(
-                adf_input.auxiliary_product_to_collection_identifier,
-                prod_type,
-            )
-            if target_collection is None:
-                raise RuntimeError(
-                    "❌ No target collection found for input product type "
-                    f"{prod_type!r} in auxiliary_product_to_collection_identifier.",
-                )
-
-            # find source from mapping
-            source: AuxiliarySource = resolve_source_name(
-                adf_input.auxiliary_product_to_collection_identifier,
-                prod_type,
-            )
 
             logger.info(f"📥 Staging {prod_type} to collection {target_collection} from source {source}")
             success, items = await aux_staging_task(

--- a/tests/test_adf_flow.py
+++ b/tests/test_adf_flow.py
@@ -26,6 +26,7 @@ from rs_workflows.flow_utils import (
     AdfProcessIn,
     AdfType,
     AuxiliaryProductMapping,
+    AuxiliarySource,
     FlowEnvArgs,
 )
 from rs_workflows.utils import utils as workflow_utils
@@ -1226,3 +1227,131 @@ async def test_adf_conversion_uses_custom_cql2_filter(
     assert staging_mock.call_count == 1
     cql2_filter_used = staging_mock.call_args.kwargs["cql2_filter"]
     assert cql2_filter_used["filter"]["args"][0]["args"][1] == "AX___MA1_AX"  # product_type substitué
+
+
+@pytest.mark.asyncio
+async def test_adf_conversion_restricts_search_to_collection_for_catalog_source(
+    monkeypatch,
+    mocker,
+    tmp_path,
+    _mock_os_env,
+    create_stac_item_mock,
+    sample_adf_process_in,
+):  # pylint: disable=redefined-outer-name,unused-argument
+    """When the AUX source is the catalog, no staging occurs: collection_name is both the source
+    and destination collection, so the default CQL2 filter must restrict the search to it,
+    otherwise the STAC search returns the most recent matching item across all collections
+    (regression test for RSPY-1044: baseline 3.23 vs 3.38 OLCI collections)."""
+    sample_adf_process_in.auxiliary_product_to_collection_identifier = [
+        AuxiliaryProductMapping(
+            product_type="AX___MA1_AX",
+            collection_name="adf-olci-baseline-3-23",
+            source=AuxiliarySource.CATALOG,
+        ),
+        AuxiliaryProductMapping(product_type="ADF_ECMWA", collection_name="ADF_PUBLISH"),
+        AuxiliaryProductMapping(product_type="*", collection_name="AUX"),
+    ]
+
+    # Mock logger & FlowEnv
+    mock_logger = MagicMock()
+    mocker.patch("rs_workflows.adf_flow.get_run_logger", return_value=mock_logger)
+
+    flow_env_mock = mocker.MagicMock()
+    flow_env_mock.start_span.return_value = MagicMock()
+    flow_env_mock.start_span.return_value.__enter__.return_value = MagicMock()
+    flow_env_mock.owner_id = "test-user"
+    flow_env_mock.serialize.return_value = FlowEnvArgs(owner_id="test-user")
+    monkeypatch.setattr(adf_flow, "FlowEnv", lambda env: flow_env_mock)
+
+    # Mock aux_staging_task — return failure so the flow exits early after staging.
+    # The test only cares about the cql2_filter argument passed to the staging call.
+    staging_mock = AsyncMock(return_value=(False, None))
+    monkeypatch.setattr(adf_flow, "aux_staging_task", staging_mock)
+
+    # Run the flow
+    await adf_flow.adf_conversion.fn(sample_adf_process_in)
+
+    # Check that the CQL2 filter restricts the search to the target collection.
+    assert staging_mock.call_count == 1
+    staging_kwargs = staging_mock.call_args.kwargs
+    assert staging_kwargs["cql2_filter"]["collections"] == ["adf-olci-baseline-3-23"]
+    assert staging_kwargs["catalog_collection_identifier"] == "adf-olci-baseline-3-23"
+    assert staging_kwargs["source"] == AuxiliarySource.CATALOG
+
+
+@pytest.mark.asyncio
+async def test_adf_conversion_default_cql2_filter_has_no_collections_for_non_catalog_source(
+    monkeypatch,
+    mocker,
+    tmp_path,
+    _mock_os_env,
+    create_stac_item_mock,
+    sample_adf_process_in,
+):  # pylint: disable=redefined-outer-name,unused-argument
+    """For a non-catalog source (e.g. auxip), collection_name is only the destination collection
+    where staged items will be uploaded: it must NOT be used to filter the search performed
+    against the external source, otherwise valid items would be silently discarded."""
+    # sample_adf_process_in's mapping uses the default AuxiliarySource.AUXIP source.
+    mock_logger = MagicMock()
+    mocker.patch("rs_workflows.adf_flow.get_run_logger", return_value=mock_logger)
+
+    flow_env_mock = mocker.MagicMock()
+    flow_env_mock.start_span.return_value = MagicMock()
+    flow_env_mock.start_span.return_value.__enter__.return_value = MagicMock()
+    flow_env_mock.owner_id = "test-user"
+    flow_env_mock.serialize.return_value = FlowEnvArgs(owner_id="test-user")
+    monkeypatch.setattr(adf_flow, "FlowEnv", lambda env: flow_env_mock)
+
+    staging_mock = AsyncMock(return_value=(False, None))
+    monkeypatch.setattr(adf_flow, "aux_staging_task", staging_mock)
+
+    await adf_flow.adf_conversion.fn(sample_adf_process_in)
+
+    assert staging_mock.call_count == 1
+    staging_kwargs = staging_mock.call_args.kwargs
+    assert staging_kwargs["source"] == AuxiliarySource.AUXIP
+    assert "collections" not in staging_kwargs["cql2_filter"]
+
+
+@pytest.mark.asyncio
+async def test_adf_conversion_honors_collection_name_with_custom_cql2_filter(
+    monkeypatch,
+    mocker,
+    tmp_path,
+    _mock_os_env,
+    create_stac_item_mock,
+    sample_adf_process_in,
+):  # pylint: disable=redefined-outer-name,unused-argument
+    """collection_name must also be honored when a custom cql2_filter is provided, not only when
+    the default filter is built."""
+    sample_adf_process_in.auxiliary_product_to_collection_identifier = [
+        AuxiliaryProductMapping(
+            product_type="AX___MA1_AX",
+            collection_name="adf-olci-baseline-3-23",
+            source=AuxiliarySource.CATALOG,
+        ),
+        AuxiliaryProductMapping(product_type="ADF_ECMWA", collection_name="ADF_PUBLISH"),
+        AuxiliaryProductMapping(product_type="*", collection_name="AUX"),
+    ]
+    sample_adf_process_in.cql2_filter = {
+        "filter": {"op": "=", "args": [{"property": "product:type"}, "{product_type}"]},
+    }
+
+    mock_logger = MagicMock()
+    mocker.patch("rs_workflows.adf_flow.get_run_logger", return_value=mock_logger)
+
+    flow_env_mock = mocker.MagicMock()
+    flow_env_mock.start_span.return_value = MagicMock()
+    flow_env_mock.start_span.return_value.__enter__.return_value = MagicMock()
+    flow_env_mock.owner_id = "test-user"
+    flow_env_mock.serialize.return_value = FlowEnvArgs(owner_id="test-user")
+    monkeypatch.setattr(adf_flow, "FlowEnv", lambda env: flow_env_mock)
+
+    staging_mock = AsyncMock(return_value=(False, None))
+    monkeypatch.setattr(adf_flow, "aux_staging_task", staging_mock)
+
+    await adf_flow.adf_conversion.fn(sample_adf_process_in)
+
+    assert staging_mock.call_count == 1
+    cql2_filter_used = staging_mock.call_args.kwargs["cql2_filter"]
+    assert cql2_filter_used["collections"] == ["adf-olci-baseline-3-23"]


### PR DESCRIPTION
Restrict the CQL2 STAC search filter to the target collection when the auxiliary source is the catalog, otherwise the most recent matching item across all collections is returned (e.g. a newer OLCI baseline collection) regardless of the collection_name configured in the ADF input mapping.